### PR TITLE
docs: Fix Gitter example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ asyncApi {
         }
     }
     components {
+        securitySchemes {
+            schema("httpBearerToken") {
+                type("http")
+                scheme("bearer")
+            }
+        }
         messages {
             message("chatMessage") {
                 summary("A message represents an individual chat message sent to a room.")


### PR DESCRIPTION
### What
- add the `httpBearerToken` security schema to the example

### Why
- the example does not produce a valid AsyncAPI document without it
- users cant copy & past the example and validate the result

### How
- add a security schema to the components object
