### PR TITLE
feat: Update model to version 2.4.0

### DIFF
--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApi.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApi.kt
@@ -46,7 +46,7 @@ class AsyncApi {
         ExternalDocumentation().apply(build).also { externalDocs = it }
 
     companion object {
-        const val VERSION = "2.3.0"
+        const val VERSION = "2.4.0"
 
         inline fun asyncApi(build: AsyncApi.() -> Unit): AsyncApi =
             AsyncApi().apply(build)

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApi.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApi.kt
@@ -1,9 +1,9 @@
 package org.openfolder.kotlinasyncapi.model
 
-import org.openfolder.kotlinasyncapi.model.channel.ChannelsMap
+import org.openfolder.kotlinasyncapi.model.channel.ReferencableChannelsMap
 import org.openfolder.kotlinasyncapi.model.component.Components
 import org.openfolder.kotlinasyncapi.model.info.Info
-import org.openfolder.kotlinasyncapi.model.server.ServersMap
+import org.openfolder.kotlinasyncapi.model.server.ReferencableServersMap
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPEALIAS)
 @DslMarker
@@ -13,9 +13,9 @@ annotation class AsyncApiComponent
 class AsyncApi {
     val asyncapi = VERSION
     lateinit var info: Info
-    lateinit var channels: ChannelsMap
+    lateinit var channels: ReferencableChannelsMap
     var id: String? = null
-    var servers: ServersMap? = null
+    var servers: ReferencableServersMap? = null
     var defaultContentType: String? = null
     var components: Components? = null
     var tags: TagsList? = null
@@ -27,11 +27,11 @@ class AsyncApi {
     inline fun info(build: Info.() -> Unit): Info =
         Info().apply(build).also { info = it }
 
-    inline fun servers(build: ServersMap.() -> Unit): ServersMap =
-        ServersMap().apply(build).also { servers = it }
+    inline fun servers(build: ReferencableServersMap.() -> Unit): ReferencableServersMap =
+        ReferencableServersMap().apply(build).also { servers = it }
 
-    inline fun channels(build: ChannelsMap.() -> Unit): ChannelsMap =
-        ChannelsMap().apply(build).also { channels = it }
+    inline fun channels(build: ReferencableChannelsMap.() -> Unit): ReferencableChannelsMap =
+        ReferencableChannelsMap().apply(build).also { channels = it }
 
     fun defaultContentType(value: String): String =
         value.also { defaultContentType = it }

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Channel.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Channel.kt
@@ -4,9 +4,12 @@ import org.openfolder.kotlinasyncapi.model.AsyncApiComponent
 import org.openfolder.kotlinasyncapi.model.Reference
 
 @AsyncApiComponent
-class ChannelsMap : LinkedHashMap<String, Channel>() {
+class ReferencableChannelsMap : LinkedHashMap<String, Any>() {
     inline fun channel(key: String, build: Channel.() -> Unit): Channel =
         Channel().apply(build).also { put(key, it) }
+
+    inline fun reference(key: String, build: Reference.() -> Unit): Reference =
+        Reference().apply(build).also { put(key, it) }
 }
 
 @AsyncApiComponent
@@ -19,6 +22,7 @@ class Channel {
     var parameters: ReferencableParametersMap? = null
     var bindings: Any? = null
 
+    @Deprecated("Usage of the \$ref property has been deprecated")
     fun ref(value: String): String =
         value.also { `$ref` = it }
 

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Message.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Message.kt
@@ -35,6 +35,7 @@ class OneOfReferencableMessages {
 
 @AsyncApiComponent
 class Message {
+    var messageId: String? = null
     var headers: Any? = null
     var payload: Any? = null
     var correlationId: Any? = null
@@ -49,6 +50,9 @@ class Message {
     var bindings: ReferencableMessageBindingsMap? = null
     var examples: MessageExamplesList? = null
     var traits: MessageTraitsList? = null
+
+    fun messageId(value: String): String =
+        value.also { messageId = it }
 
     inline fun headers(build: Schema.() -> Unit): Schema =
         Schema().apply(build).also { headers = it }

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Operation.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Operation.kt
@@ -4,12 +4,14 @@ import org.openfolder.kotlinasyncapi.model.AsyncApiComponent
 import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
 import org.openfolder.kotlinasyncapi.model.Reference
 import org.openfolder.kotlinasyncapi.model.TagsList
+import org.openfolder.kotlinasyncapi.model.server.SecurityRequirementsList
 
 @AsyncApiComponent
 class Operation {
     var operationId: String? = null
     var summary: String? = null
     var description: String? = null
+    var security: SecurityRequirementsList? = null
     var tags: TagsList? = null
     var externalDocs: ExternalDocumentation? = null
     var bindings: Any? = null
@@ -24,6 +26,9 @@ class Operation {
 
     fun description(value: String): String =
         value.also { description = it }
+
+    inline fun security(build: SecurityRequirementsList.() -> Unit): SecurityRequirementsList =
+        SecurityRequirementsList().apply(build).also { security = it }
 
     inline fun tags(build: TagsList.() -> Unit): TagsList =
         TagsList().apply(build).also { tags = it }

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/component/Components.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/component/Components.kt
@@ -3,8 +3,8 @@ package org.openfolder.kotlinasyncapi.model.component
 import org.openfolder.kotlinasyncapi.model.AsyncApiComponent
 import org.openfolder.kotlinasyncapi.model.ReferencableCorrelationIDsMap
 import org.openfolder.kotlinasyncapi.model.ReferencableSchemasMap
-import org.openfolder.kotlinasyncapi.model.channel.ChannelsMap
 import org.openfolder.kotlinasyncapi.model.channel.ReferencableChannelBindingsMap
+import org.openfolder.kotlinasyncapi.model.channel.ReferencableChannelsMap
 import org.openfolder.kotlinasyncapi.model.channel.ReferencableMessageBindingsMap
 import org.openfolder.kotlinasyncapi.model.channel.ReferencableMessageTraitsMap
 import org.openfolder.kotlinasyncapi.model.channel.ReferencableMessagesMap
@@ -12,13 +12,15 @@ import org.openfolder.kotlinasyncapi.model.channel.ReferencableOperationBindings
 import org.openfolder.kotlinasyncapi.model.channel.ReferencableOperationTraitsMap
 import org.openfolder.kotlinasyncapi.model.channel.ReferencableParametersMap
 import org.openfolder.kotlinasyncapi.model.server.ReferencableServerBindingsMap
+import org.openfolder.kotlinasyncapi.model.server.ReferencableServerVariablesMap
 import org.openfolder.kotlinasyncapi.model.server.ReferencableServersMap
 
 @AsyncApiComponent
 class Components {
     var schemas: ReferencableSchemasMap? = null
     var servers: ReferencableServersMap? = null
-    var channels: ChannelsMap? = null
+    var serverVariables: ReferencableServerVariablesMap? = null
+    var channels: ReferencableChannelsMap? = null
     var messages: ReferencableMessagesMap? = null
     var securitySchemes: ReferencableSecuritySchemasMap? = null
     var parameters: ReferencableParametersMap? = null
@@ -36,8 +38,11 @@ class Components {
     inline fun servers(build: ReferencableServersMap.() -> Unit): ReferencableServersMap =
         ReferencableServersMap().apply(build).also { servers = it }
 
-    inline fun channels(build: ChannelsMap.() -> Unit): ChannelsMap =
-        ChannelsMap().apply(build).also { channels = it }
+    inline fun serverVariables(build: ReferencableServerVariablesMap.() -> Unit): ReferencableServerVariablesMap =
+        ReferencableServerVariablesMap().apply(build).also { serverVariables = it }
+
+    inline fun channels(build: ReferencableChannelsMap.() -> Unit): ReferencableChannelsMap =
+        ReferencableChannelsMap().apply(build).also { channels = it }
 
     inline fun messages(build: ReferencableMessagesMap.() -> Unit): ReferencableMessagesMap =
         ReferencableMessagesMap().apply(build).also { messages = it }

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/server/Server.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/server/Server.kt
@@ -5,12 +5,6 @@ import org.openfolder.kotlinasyncapi.model.Reference
 import java.util.AbstractMap
 
 @AsyncApiComponent
-class ServersMap : LinkedHashMap<String, Server>() {
-    inline fun server(key: String, build: Server.() -> Unit): Server =
-        Server().apply(build).also { put(key, it) }
-}
-
-@AsyncApiComponent
 class ReferencableServersMap : LinkedHashMap<String, Any>() {
     inline fun server(key: String, build: Server.() -> Unit): Server =
         Server().apply(build).also { put(key, it) }
@@ -31,7 +25,7 @@ class Server {
     lateinit var protocol: String
     var protocolVersion: String? = null
     var description: String? = null
-    var variables: ServerVariablesMap? = null
+    var variables: ReferencableServerVariablesMap? = null
     var security: SecurityRequirementsList? = null
     var bindings: Any? = null
 
@@ -47,8 +41,8 @@ class Server {
     fun description(value: String): String =
         value.also { description = it }
 
-    inline fun variables(build: ServerVariablesMap.() -> Unit): ServerVariablesMap =
-        ServerVariablesMap().apply(build).also { variables = it }
+    inline fun variables(build: ReferencableServerVariablesMap.() -> Unit): ReferencableServerVariablesMap =
+        ReferencableServerVariablesMap().apply(build).also { variables = it }
 
     inline fun security(build: SecurityRequirementsList.() -> Unit): SecurityRequirementsList =
         SecurityRequirementsList().apply(build).also { security = it }

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerVariable.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerVariable.kt
@@ -1,11 +1,15 @@
 package org.openfolder.kotlinasyncapi.model.server
 
 import org.openfolder.kotlinasyncapi.model.AsyncApiComponent
+import org.openfolder.kotlinasyncapi.model.Reference
 
 @AsyncApiComponent
-class ServerVariablesMap : LinkedHashMap<String, ServerVariable>() {
+class ReferencableServerVariablesMap : LinkedHashMap<String, Any>() {
     inline fun variable(key: String, build: ServerVariable.() -> Unit): ServerVariable =
         ServerVariable().apply(build).also { put(key, it) }
+
+    inline fun reference(key: String, build: Reference.() -> Unit): Reference =
+        Reference().apply(build).also { put(key, it) }
 }
 
 @AsyncApiComponent

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApiIntegrationTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApiIntegrationTest.kt
@@ -1,9 +1,9 @@
 package org.openfolder.kotlinasyncapi.model
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.AsyncApi.Companion.asyncApi
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class AsyncApiIntegrationTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApiTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/AsyncApiTest.kt
@@ -1,11 +1,11 @@
 package org.openfolder.kotlinasyncapi.model
 
-import org.openfolder.kotlinasyncapi.model.info.Info
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.info.Info
 
 internal class AsyncApiTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/CorrelationIDTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/CorrelationIDTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class CorrelationIDTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/ExternalDocumentationTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/ExternalDocumentationTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ExternalDocumentationTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/ReferenceTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/ReferenceTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ReferenceTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/SchemaTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/SchemaTest.kt
@@ -1,12 +1,12 @@
 package org.openfolder.kotlinasyncapi.model
 
-import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
-import org.openfolder.kotlinasyncapi.model.TestUtils.json
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
+import org.openfolder.kotlinasyncapi.model.TestUtils.json
 
 internal class SchemaTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/TagTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/TagTest.kt
@@ -1,12 +1,12 @@
 package org.openfolder.kotlinasyncapi.model
 
-import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
-import org.openfolder.kotlinasyncapi.model.TestUtils.json
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
+import org.openfolder.kotlinasyncapi.model.TestUtils.json
 
 internal class TagTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/ChannelBindingTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/ChannelBindingTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ChannelBindingTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/ChannelTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/ChannelTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ChannelTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageBindingTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageBindingTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class MessageBindingTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageExampleTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageExampleTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class MessageExampleTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageTest.kt
@@ -1,14 +1,14 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
-import org.openfolder.kotlinasyncapi.model.CorrelationID
-import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
-import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
-import org.openfolder.kotlinasyncapi.model.TestUtils.json
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.CorrelationID
+import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
+import org.openfolder.kotlinasyncapi.model.TestUtils.json
 
 internal class MessageTest {
 
@@ -29,6 +29,7 @@ internal class MessageTest {
         } returns "mocked"
 
         val message = Message().apply {
+            messageId("messageIdValue")
             headers { }
             payload { }
             correlationId { }

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageTraitTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageTraitTest.kt
@@ -1,14 +1,14 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
-import org.openfolder.kotlinasyncapi.model.CorrelationID
-import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
-import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
-import org.openfolder.kotlinasyncapi.model.TestUtils.json
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.CorrelationID
+import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
+import org.openfolder.kotlinasyncapi.model.TestUtils.json
 
 internal class MessageTraitTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/OperationBindingTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/OperationBindingTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class OperationBindingTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/OperationTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/OperationTest.kt
@@ -1,13 +1,13 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
-import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
-import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
-import org.openfolder.kotlinasyncapi.model.TestUtils.json
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
+import org.openfolder.kotlinasyncapi.model.TestUtils.json
 
 internal class OperationTest {
 
@@ -27,6 +27,7 @@ internal class OperationTest {
             operationId("operationIdValue")
             summary("summaryValue")
             description("descriptionValue")
+            security { }
             tags { }
             externalDocs { }
             bindings { }

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/OperationTraitTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/OperationTraitTest.kt
@@ -1,13 +1,13 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
-import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
-import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
-import org.openfolder.kotlinasyncapi.model.TestUtils.json
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
+import org.openfolder.kotlinasyncapi.model.TestUtils.json
 
 internal class OperationTraitTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/ParameterTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/channel/ParameterTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.channel
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ParameterTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/component/ComponentsTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/component/ComponentsTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.component
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ComponentsTest {
 
@@ -11,6 +11,7 @@ internal class ComponentsTest {
         val components = Components().apply {
             schemas { }
             servers { }
+            serverVariables { }
             channels { }
             messages { }
             securitySchemes { }

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/component/OAuthFlowsTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/component/OAuthFlowsTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.component
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class OAuthFlowsTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/component/SecuritySchemaTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/component/SecuritySchemaTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.component
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class SecuritySchemaTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/info/ContactTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/info/ContactTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.info
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ContactTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/info/InfoTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/info/InfoTest.kt
@@ -1,12 +1,12 @@
 package org.openfolder.kotlinasyncapi.model.info
 
-import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
-import org.openfolder.kotlinasyncapi.model.TestUtils.json
 import io.mockk.clearConstructorMockk
 import io.mockk.every
 import io.mockk.mockkConstructor
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
+import org.openfolder.kotlinasyncapi.model.TestUtils.json
 
 internal class InfoTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/info/LicenseTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/info/LicenseTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.info
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class LicenseTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerBindingTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerBindingTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.server
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ServerBindingTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.server
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ServerTest {
 

--- a/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerVariableTest.kt
+++ b/kotlin-asyncapi-core/src/test/kotlin/org/openfolder/kotlinasyncapi/model/server/ServerVariableTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.model.server
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.TestUtils.assertJsonEquals
 import org.openfolder.kotlinasyncapi.model.TestUtils.json
-import org.junit.jupiter.api.Test
 
 internal class ServerVariableTest {
 

--- a/kotlin-asyncapi-core/src/test/resources/async_api.json
+++ b/kotlin-asyncapi-core/src/test/resources/async_api.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi": "2.3.0",
+  "asyncapi": "2.4.0",
   "id": "idValue",
   "defaultContentType": "defaultContentTypeValue",
   "info": {

--- a/kotlin-asyncapi-core/src/test/resources/async_api_integration.json
+++ b/kotlin-asyncapi-core/src/test/resources/async_api_integration.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi" : "2.3.0",
+  "asyncapi" : "2.4.0",
   "info" : {
     "title" : "Gitter Streaming API",
     "version" : "1.0.0"

--- a/kotlin-asyncapi-core/src/test/resources/channel/message.json
+++ b/kotlin-asyncapi-core/src/test/resources/channel/message.json
@@ -1,4 +1,5 @@
 {
+  "messageId" : "messageIdValue",
   "headers" : { },
   "payload" : { },
   "correlationId" : {

--- a/kotlin-asyncapi-core/src/test/resources/channel/operation.json
+++ b/kotlin-asyncapi-core/src/test/resources/channel/operation.json
@@ -2,6 +2,7 @@
   "operationId" : "operationIdValue",
   "summary" : "summaryValue",
   "description" : "descriptionValue",
+  "security" : [ ],
   "tags" : [ ],
   "externalDocs" : {
     "url" : "mocked"

--- a/kotlin-asyncapi-core/src/test/resources/component/components.json
+++ b/kotlin-asyncapi-core/src/test/resources/component/components.json
@@ -1,6 +1,7 @@
 {
   "schemas" : { },
   "servers" : { },
+  "serverVariables" : { },
   "channels" : { },
   "messages" : { },
   "securitySchemes" : { },

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/controller/AsyncApiControllerIntegrationTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/controller/AsyncApiControllerIntegrationTest.kt
@@ -1,9 +1,9 @@
 package org.openfolder.kotlinasyncapi.springweb.controller
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.springweb.EnableAsyncApi
 import org.openfolder.kotlinasyncapi.springweb.TestUtils
 import org.openfolder.kotlinasyncapi.springweb.service.AsyncApiExtension
-import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiSerializerTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiSerializerTest.kt
@@ -1,8 +1,8 @@
 package org.openfolder.kotlinasyncapi.springweb.service
 
+import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.model.AsyncApi
 import org.openfolder.kotlinasyncapi.springweb.TestUtils.json
-import org.junit.jupiter.api.Test
 import org.skyscreamer.jsonassert.JSONAssert
 import org.skyscreamer.jsonassert.JSONCompareMode
 

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiServiceTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiServiceTest.kt
@@ -1,6 +1,5 @@
 package org.openfolder.kotlinasyncapi.springweb.service
 
-import org.openfolder.kotlinasyncapi.model.AsyncApi
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
@@ -9,6 +8,7 @@ import io.mockk.slot
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.openfolder.kotlinasyncapi.model.AsyncApi
 
 @ExtendWith(MockKExtension::class)
 internal class DefaultAsyncApiServiceTest {

--- a/kotlin-asyncapi-spring-web/src/test/resources/async_api_integration.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/async_api_integration.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi" : "2.3.0",
+  "asyncapi" : "2.4.0",
   "info" : {
     "title" : "Gitter Streaming API",
     "version" : "1.0.0"

--- a/kotlin-asyncapi-spring-web/src/test/resources/async_api_serialization.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/async_api_serialization.json
@@ -1,5 +1,5 @@
 {
-  "asyncapi" : "2.3.0",
+  "asyncapi" : "2.4.0",
   "info" : {
     "title" : "Gitter Streaming API",
     "version" : "1.0.0"


### PR DESCRIPTION
### What
Update the supported AsyncAPI specs version to 2.4.0

### Why
- support new features
- fix bugs

### How
- follow release notes of v2.4.0 at https://github.com/asyncapi/spec/releases/tag/v2.4.0
