### PR TITLE
feat: Add default info extension

### DIFF
--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
@@ -6,8 +6,10 @@ import org.openfolder.kotlinasyncapi.springweb.service.AsyncApiSerializer
 import org.openfolder.kotlinasyncapi.springweb.service.AsyncApiService
 import org.openfolder.kotlinasyncapi.springweb.service.DefaultAsyncApiSerializer
 import org.openfolder.kotlinasyncapi.springweb.service.DefaultAsyncApiService
+import org.openfolder.kotlinasyncapi.springweb.service.DefaultInfoProvider
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -21,8 +23,21 @@ internal open class AsyncApiAutoConfiguration {
         DefaultAsyncApiSerializer()
 
     @Bean
-    open fun asyncApiService(extension: AsyncApiExtension?): AsyncApiService =
-        DefaultAsyncApiService(extension)
+    open fun infoProvider(context: ApplicationContext) =
+        DefaultInfoProvider(context)
+
+    @Bean
+    open fun asyncApiDefaultInfoExtension(infoProvider: DefaultInfoProvider) =
+        AsyncApiExtension.builder(order = -1) {
+            info {
+                infoProvider.title?.let { title(it) }
+                infoProvider.version?.let { version(it) }
+            }
+        }
+
+    @Bean
+    open fun asyncApiService(extensions: List<AsyncApiExtension>): AsyncApiService =
+        DefaultAsyncApiService(extensions)
 
     @Bean
     open fun asyncApiController(service: AsyncApiService, serializer: AsyncApiSerializer): AsyncApiController =

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/service/AsyncApiExtension.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/service/AsyncApiExtension.kt
@@ -2,7 +2,12 @@ package org.openfolder.kotlinasyncapi.springweb.service
 
 import org.openfolder.kotlinasyncapi.model.AsyncApi
 
-fun interface AsyncApiExtension {
+interface AsyncApiExtension {
+
+    /**
+     * Extensions with higher values overwrite extensions with lower values.
+     */
+    val order: Int
 
     /**
      * Extends the generated AsyncApi resource
@@ -10,7 +15,10 @@ fun interface AsyncApiExtension {
     fun extend(asyncApi: AsyncApi): AsyncApi
 
     companion object {
-        fun builder(build: AsyncApi.() -> Unit): AsyncApiExtension =
-            AsyncApiExtension { asyncApi -> asyncApi.apply(build) }
+        fun builder(order: Int = 0, build: AsyncApi.() -> Unit): AsyncApiExtension =
+            object : AsyncApiExtension {
+                override val order = order
+                override fun extend(asyncApi: AsyncApi) = asyncApi.apply(build)
+            }
     }
 }

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiService.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiService.kt
@@ -5,10 +5,13 @@ import org.springframework.stereotype.Service
 
 @Service
 internal class DefaultAsyncApiService(
-    extension: AsyncApiExtension?
+    extensions: List<AsyncApiExtension>
 ) : AsyncApiService {
-
-    private val asyncApi by lazy { AsyncApi().apply { extension?.extend(this) } }
+    private val asyncApi by lazy {
+        AsyncApi().apply {
+            extensions.sortedBy { it.order }.forEach { it.extend(this) }
+        }
+    }
 
     override fun asyncApi() = asyncApi
 }

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultInfoProvider.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultInfoProvider.kt
@@ -1,0 +1,21 @@
+package org.openfolder.kotlinasyncapi.springweb.service
+
+import org.openfolder.kotlinasyncapi.springweb.EnableAsyncApi
+import org.springframework.context.ApplicationContext
+import org.springframework.stereotype.Service
+
+@Service
+internal class DefaultInfoProvider(
+    context: ApplicationContext
+) {
+    private val applicationPackage = context
+        .getBeansWithAnnotation(EnableAsyncApi::class.java)
+        .values
+        .firstOrNull()
+        ?.javaClass
+        ?.`package`
+
+    val title by lazy { applicationPackage?.implementationTitle }
+
+    val version by lazy { applicationPackage?.implementationVersion }
+}

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/controller/AsyncApiControllerIntegrationTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/controller/AsyncApiControllerIntegrationTest.kt
@@ -40,10 +40,6 @@ internal class AsyncApiControllerIntegrationTest {
         open fun asyncApiExtension() =
             AsyncApiExtension.builder {
                 id("urn:com:gitter:streaming:api")
-                info {
-                    title("Gitter Streaming API")
-                    version("1.0.0")
-                }
                 servers {
                     server("production") {
                         url("https://stream.gitter.im/v1")
@@ -147,6 +143,24 @@ internal class AsyncApiControllerIntegrationTest {
                             }
                         }
                     }
+                }
+            }
+
+        @Bean
+        open fun asyncApiExtension2() =
+            AsyncApiExtension.builder(order = 10) {
+                info {
+                    description("Gitter Streaming API Description")
+                }
+            }
+
+        @Bean
+        open fun asyncApiExtension3() =
+            AsyncApiExtension.builder(order = 20) {
+                info {
+                    title("Gitter Streaming API")
+                    version("1.0.0")
+                    description("Gitter Streaming API Final Description")
                 }
             }
     }

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiServiceTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/service/DefaultAsyncApiServiceTest.kt
@@ -1,9 +1,8 @@
 package org.openfolder.kotlinasyncapi.springweb.service
 
 import io.mockk.every
-import io.mockk.impl.annotations.InjectMockKs
-import io.mockk.impl.annotations.MockK
 import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
 import io.mockk.slot
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -13,15 +12,12 @@ import org.openfolder.kotlinasyncapi.model.AsyncApi
 @ExtendWith(MockKExtension::class)
 internal class DefaultAsyncApiServiceTest {
 
-    @MockK
-    private lateinit var asyncApiExtension: AsyncApiExtension
-
-    @InjectMockKs
-    private lateinit var asyncApiService: DefaultAsyncApiService
-
     @Test
     fun `should extend AsyncApi document`() {
         val asyncApi = slot<AsyncApi>()
+        val asyncApiExtension = mockk<AsyncApiExtension>()
+        val asyncApiExtensions = listOf(asyncApiExtension)
+        val asyncApiService = DefaultAsyncApiService(asyncApiExtensions)
         every {
             asyncApiExtension.extend(capture(asyncApi))
         } answers {

--- a/kotlin-asyncapi-spring-web/src/test/resources/async_api_integration.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/async_api_integration.json
@@ -2,7 +2,8 @@
   "asyncapi" : "2.4.0",
   "info" : {
     "title" : "Gitter Streaming API",
-    "version" : "1.0.0"
+    "version" : "1.0.0",
+    "description" : "Gitter Streaming API Final Description"
   },
   "id" : "urn:com:gitter:streaming:api",
   "servers" : {


### PR DESCRIPTION
### What
If no AsyncAPI extension is provided for the application context, the service fails because the info field is required. We need to add a default info extension to the context.

### Why
- avoid errors for minimal configuration

### How
- use the manifest title and version
