### PR TITLE
feat: Add default channels extension

### DIFF
--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
@@ -36,6 +36,12 @@ internal open class AsyncApiAutoConfiguration {
         }
 
     @Bean
+    open fun asyncApiDefaultChannelsExtension() =
+        AsyncApiExtension.builder(order = -1) {
+            channels { }
+        }
+
+    @Bean
     open fun asyncApiService(extensions: List<AsyncApiExtension>): AsyncApiService =
         DefaultAsyncApiService(extensions)
 


### PR DESCRIPTION
### What
If no AsyncAPI extension is provided for the application context, the service fails because the channels field is required. We need to add a default channels extension to the context.

### Why
- avoid errors for minimal configuration

### How
- use an empty channels map
