### PR TITLE
docs: Clarify default extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,12 @@ asyncApi {
 
 ### Spring Web
 To serve your AsyncAPI specification via Spring Web:
-- enable the autoconfiguration by annotating a configuration class with`@EnableAsyncApi`
+- enable the autoconfiguration by annotating a configuration class with `@EnableAsyncApi`
 - provide an `AsyncApiExtension` bean for the application context
+
+The library registers a default `info` extension using the `Implementation-Title` and `Implementation-Version` of the `MANIFEST.md` file. Please note that this information is only available if the application was started from a JAR file. The default info will **not** work if you start the application from your IDE.
+
+You can register multiple extensions to extend and override AsyncAPI components. Extensions with a higher order override extensions with a lower order. Please note that currently you can only extend top-level components. like `info`, `channels` or `servers`. Subcomponents will always be overwritten.
 
 **Example** (simplified version of [Gitter example](https://github.com/asyncapi/spec/blob/22c6f2c7a61846338bfbd43d81024cb12cf4ed5f/examples/gitter-streaming.yml))
 ```kotlin


### PR DESCRIPTION
### What
Document the added default info extension and multi-extension support.

### Why
- let people know how to use it

### How
- extend the README
