### PR TITLE
feat: Provide default info component for plugin

### DIFF
--- a/kotlin-asyncapi-maven-plugin/src/main/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPlugin.kt
+++ b/kotlin-asyncapi-maven-plugin/src/main/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPlugin.kt
@@ -6,6 +6,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.project.MavenProject
+import org.openfolder.kotlinasyncapi.model.AsyncApi
 import java.io.File
 import javax.inject.Inject
 
@@ -33,12 +34,23 @@ internal class AsyncApiPlugin @Inject constructor(
     lateinit var project: MavenProject
 
     override fun execute() {
-        val asyncApi = scriptRunner.run(File(sourcePath))
+        val asyncApi = AsyncApi.asyncApi {
+            info {
+                title(project.name)
+                version(project.version)
+                description(project.description)
+            }
+            channels { }
+        }
+        scriptRunner.run(
+            script = File(sourcePath),
+            receiver = asyncApi
+        )
+
         val fullTargetPath = "./target/$targetPath".let {
             if (it.last() != '/') it.plus('/')
             else it
         }
-
         log.info("Writing $targetFileName to $fullTargetPath")
         fileWriter.write(
             asyncApi = asyncApi,

--- a/kotlin-asyncapi-maven-plugin/src/main/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiScriptRunner.kt
+++ b/kotlin-asyncapi-maven-plugin/src/main/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiScriptRunner.kt
@@ -10,7 +10,7 @@ import kotlin.script.experimental.host.toScriptSource
 import kotlin.script.experimental.jvmhost.BasicJvmScriptingHost
 
 internal interface AsyncApiScriptRunner {
-    fun run(script: File): AsyncApi
+    fun run(script: File, receiver: AsyncApi = AsyncApi()): AsyncApi
 }
 
 @Singleton
@@ -19,16 +19,13 @@ internal class AsyncApiScriptHost : AsyncApiScriptRunner {
 
     private val jvmScriptingHost = BasicJvmScriptingHost()
 
-    override fun run(script: File): AsyncApi {
-        val scriptReceiver = AsyncApi()
-
-        jvmScriptingHost.evalWithTemplate<AsyncApiScript>(
-            script = script.toScriptSource(),
-            evaluation = {
-                implicitReceivers(scriptReceiver)
-            }
-        )
-
-        return scriptReceiver
-    }
+    override fun run(script: File, receiver: AsyncApi) =
+        receiver.also {
+            jvmScriptingHost.evalWithTemplate<AsyncApiScript>(
+                script = script.toScriptSource(),
+                evaluation = {
+                    implicitReceivers(it)
+                }
+            )
+        }
 }

--- a/kotlin-asyncapi-maven-plugin/src/test/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPluginTest.kt
+++ b/kotlin-asyncapi-maven-plugin/src/test/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPluginTest.kt
@@ -42,7 +42,7 @@ internal class AsyncApiPluginTest {
         }
 
         every {
-            scriptRunner.run(any())
+            scriptRunner.run(any(), any())
         } returns asyncApi
         every {
             fileWriter.write(capture(asyncApiSlot), json)
@@ -55,7 +55,7 @@ internal class AsyncApiPluginTest {
         }.execute()
 
         verify {
-            scriptRunner.run(script)
+            scriptRunner.run(script, ofType(AsyncApi::class))
             fileWriter.write(asyncApiSlot.captured, json)
             mavenProject.addResource(any())
         }


### PR DESCRIPTION
### What
- use the maven project properties to provide a default info component and build a valid AsyncAPI base

### Why
- to avoid errors if info or channels is not configured 

### How
- use project.name, project.version and project.description as default info values
