### PR TITLE
fix: Support multi-module projects in plugin

### DIFF
--- a/kotlin-asyncapi-maven-plugin/src/main/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPlugin.kt
+++ b/kotlin-asyncapi-maven-plugin/src/main/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPlugin.kt
@@ -44,28 +44,25 @@ internal class AsyncApiPlugin @Inject constructor(
             channels { }
         }
         scriptRunner.run(
-            script = File(sourcePath),
+            script = File(project.basedir, sourcePath),
             receiver = asyncApi
         )
 
-        val fullTargetPath = "./target/$targetPath".let {
-            if (it.last() != '/') it.plus('/')
-            else it
-        }
-        log.info("Writing $targetFileName to $fullTargetPath")
+        val targetDir = File(project.basedir, "target/$targetPath")
+        log.info("Writing $targetFileName to $targetDir")
         fileWriter.write(
             asyncApi = asyncApi,
-            file = File(fullTargetPath, targetFileName)
+            file = File(targetDir, targetFileName)
         )
 
         if (packageResources) {
             val resource = Resource().also {
-                it.directory = fullTargetPath
+                it.directory = targetDir.path
                 it.includes = listOf(targetFileName)
                 it.targetPath = targetPath
             }
 
-            log.info("Adding $fullTargetPath to resources")
+            log.info("Adding $targetDir to resources")
             project.addResource(resource)
         }
     }

--- a/kotlin-asyncapi-maven-plugin/src/test/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPluginTest.kt
+++ b/kotlin-asyncapi-maven-plugin/src/test/kotlin/org/openfolder/kotlinasyncapi/mavenplugin/AsyncApiPluginTest.kt
@@ -30,8 +30,8 @@ internal class AsyncApiPluginTest {
 
     @Test
     fun `should generate resource and write it to the target`() {
-        val script = File("test/source")
-        val json = File("./target/test/target/asyncapi.json")
+        val script = File("./test/source")
+        val json = File("./target/test/generated/asyncapi.json")
         val asyncApiSlot = slot<AsyncApi>()
         val asyncApi = AsyncApi.asyncApi {
             info {
@@ -47,10 +47,13 @@ internal class AsyncApiPluginTest {
         every {
             fileWriter.write(capture(asyncApiSlot), json)
         } returns Unit
+        every {
+            mavenProject.basedir
+        } returns File("./")
 
         plugin.apply {
             sourcePath = "test/source"
-            targetPath = "test/target"
+            targetPath = "test/generated"
             project = mavenProject
         }.execute()
 


### PR DESCRIPTION
### What
- use the project base path of the executing module instead of the user path of the executing Maven command

### Why
- multi-module project support was limited (looked in the parent dir for the script file and wrote to parent target)

### How
- use the base dir of the current Maven project
