### PR TITLE
feat: Implement message model annotations

### DIFF
--- a/kotlin-asyncapi-annotation/pom.xml
+++ b/kotlin-asyncapi-annotation/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.openfolder</groupId>
+        <artifactId>kotlin-asyncapi-parent</artifactId>
+        <version>2.1.4-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kotlin-asyncapi-annotation</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Kotlin AsyncAPI Annotation</name>
+    <description>AsyncAPI annotations for meta-documentation</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/kotlin-asyncapi-annotation/pom.xml
+++ b/kotlin-asyncapi-annotation/pom.xml
@@ -13,17 +13,4 @@
 
     <name>Kotlin AsyncAPI Annotation</name>
     <description>AsyncAPI annotations for meta-documentation</description>
-
-    <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 </project>

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/CorrelationID.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/CorrelationID.kt
@@ -1,0 +1,8 @@
+package org.openfolder.kotlinasyncapi.annotation
+
+annotation class CorrelationID(
+    val default: Boolean = false,
+    val reference: String = "",
+    val location: String,
+    val description: String = ""
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/ExternalDocumentation.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/ExternalDocumentation.kt
@@ -1,0 +1,7 @@
+package org.openfolder.kotlinasyncapi.annotation
+
+annotation class ExternalDocumentation(
+    val default: Boolean = false,
+    val url: String,
+    val description: String = ""
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/Schema.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/Schema.kt
@@ -1,0 +1,35 @@
+package org.openfolder.kotlinasyncapi.annotation
+
+import kotlin.reflect.KClass
+
+annotation class Schema(
+    val default: Boolean = false,
+    val reference: String = "",
+    val title: String = "",
+    val description: String = "",
+    val implementation: KClass<*> = Void::class,
+    val readOnly: Boolean = false,
+    val writeOnly: Boolean = false,
+    val examples: Array<String> = [],
+    val type: String = "",
+    val multipleOf: Int = 0,
+    val maximum: Int = 0,
+    val exclusiveMaximum: Int = 0,
+    val minimum: Int = 0,
+    val exclusiveMinimum: Int = 0,
+    val maxLength: Int = 0,
+    val minLength: Int = 0,
+    val pattern: String = "",
+    val maxProperties: Int = 0,
+    val minProperties: Int = 0,
+    val required: Array<String> = [],
+    val additionalProperties: String = "",
+    val allOf: Array<KClass<*>> = [],
+    val anyOf: Array<KClass<*>> = [],
+    val oneOf: Array<KClass<*>> = [],
+    val not: KClass<*> = Void::class,
+    val format: String = "",
+    val discriminator: String = "",
+    val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
+    val deprecated: Boolean = false
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/Tag.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/Tag.kt
@@ -1,0 +1,8 @@
+package org.openfolder.kotlinasyncapi.annotation
+
+annotation class Tag(
+    val default: Boolean = false,
+    val name: String,
+    val description: String = "",
+    val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = "")
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Message.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Message.kt
@@ -1,0 +1,33 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.CorrelationID
+import org.openfolder.kotlinasyncapi.annotation.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.annotation.Schema
+import org.openfolder.kotlinasyncapi.annotation.Tag
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.ANNOTATION_CLASS
+)
+@Repeatable
+annotation class Message(
+    val default: Boolean = false,
+    val reference: String = "",
+    val messageId: String = "",
+    val schemaFormat: String = "",
+    val contentType: String = "",
+    val name: String = "",
+    val title: String = "",
+    val summary: String = "",
+    val description: String = "",
+    val headers: Array<Schema> = [],
+    val payload: Schema = Schema(),
+    val correlationId: CorrelationID = CorrelationID(default = true, location = ""),
+    val tags: Array<Tag> = [],
+    val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
+    val examples: Array<MessageExample> = [],
+    val bindings: MessageBindings = MessageBindings(default = true),
+    val traits: Array<MessageTrait> = []
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageBinding.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageBinding.kt
@@ -1,0 +1,89 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.Schema
+
+annotation class MessageBindings(
+    val default: Boolean = false,
+    val reference: String = "",
+    val http: MessageBinding.HTTP = MessageBinding.HTTP(default = true),
+    val ws: MessageBinding.WebSockets = MessageBinding.WebSockets(default = true),
+    val kafka: MessageBinding.Kafka = MessageBinding.Kafka(default = true),
+    val anypointmq: MessageBinding.AnypointMQ = MessageBinding.AnypointMQ(default = true),
+    val amqp: MessageBinding.AMQP = MessageBinding.AMQP(default = true),
+    val amqp1: MessageBinding.AMQP1 = MessageBinding.AMQP1(default = true),
+    val mqtt: MessageBinding.MQTT = MessageBinding.MQTT(default = true),
+    val mqtt5: MessageBinding.MQTT5 = MessageBinding.MQTT5(default = true),
+    val nats: MessageBinding.NATS = MessageBinding.NATS(default = true),
+    val jms: MessageBinding.JMS = MessageBinding.JMS(default = true),
+    val sns: MessageBinding.SNS = MessageBinding.SNS(default = true),
+    val solace: MessageBinding.Solace = MessageBinding.Solace(default = true),
+    val sqs: MessageBinding.SQS = MessageBinding.SQS(default = true),
+    val stomp: MessageBinding.STOMP = MessageBinding.STOMP(default = true),
+    val redis: MessageBinding.Redis = MessageBinding.Redis(default = true),
+    val mercure: MessageBinding.Mercure = MessageBinding.Mercure(default = true),
+    val ibmmq: MessageBinding.IBMMQ = MessageBinding.IBMMQ(default = true)
+)
+
+sealed interface MessageBinding {
+
+    annotation class HTTP(
+        val default: Boolean = false,
+        val headers: Schema = Schema(default = true),
+        val bindingVersion: String = ""
+    )
+
+    annotation class Kafka(
+        val default: Boolean = false,
+        val key: Schema = Schema(default = true),
+        val bindingVersion: String = ""
+    )
+
+    annotation class AnypointMQ(
+        val default: Boolean = false,
+        val headers: Schema = Schema(default = true),
+        val bindingVersion: String = ""
+    )
+
+    annotation class AMQP(
+        val default: Boolean = false,
+        val contentEncoding: String = "",
+        val messageType: String = "",
+        val bindingVersion: String = ""
+    )
+
+    annotation class MQTT(
+        val default: Boolean = false,
+        val bindingVersion: String = ""
+    )
+
+    annotation class IBMMQ(
+        val default: Boolean = false,
+        val type: String = "",
+        val headers: String = "",
+        val description: String = "",
+        val expiry: Int = 0,
+        val bindingVersion: String = ""
+    )
+
+    annotation class WebSockets(val default: Boolean = false)
+
+    annotation class AMQP1(val default: Boolean = false)
+
+    annotation class MQTT5(val default: Boolean = false)
+
+    annotation class NATS(val default: Boolean = false)
+
+    annotation class JMS(val default: Boolean = false)
+
+    annotation class SNS(val default: Boolean = false)
+
+    annotation class Solace(val default: Boolean = false)
+
+    annotation class SQS(val default: Boolean = false)
+
+    annotation class STOMP(val default: Boolean = false)
+
+    annotation class Redis(val default: Boolean = false)
+
+    annotation class Mercure(val default: Boolean = false)
+}

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageExample.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageExample.kt
@@ -1,0 +1,11 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.Schema
+
+annotation class MessageExample(
+    val default: Boolean = false,
+    val headers: Schema = Schema(default = true),
+    val payload: String = "",
+    val name: String = "",
+    val summary: String = ""
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageTrait.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageTrait.kt
@@ -1,0 +1,24 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.CorrelationID
+import org.openfolder.kotlinasyncapi.annotation.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.annotation.Schema
+import org.openfolder.kotlinasyncapi.annotation.Tag
+
+annotation class MessageTrait(
+    val default: Boolean = false,
+    val reference: String = "",
+    val messageId: String = "",
+    val schemaFormat: String = "",
+    val contentType: String = "",
+    val name: String = "",
+    val title: String = "",
+    val summary: String = "",
+    val description: String = "",
+    val headers: Array<Schema> = [],
+    val correlationId: CorrelationID = CorrelationID(default = true, location = ""),
+    val tags: Array<Tag> = [],
+    val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
+    val examples: Array<MessageExample> = [],
+    val bindings: MessageBindings = MessageBindings(default = true)
+)

--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageTrait.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/MessageTrait.kt
@@ -26,6 +26,7 @@ class ReferencableMessageTraitsMap : LinkedHashMap<String, Any>() {
 class MessageTrait {
     var headers: Any? = null
     var correlationId: Any? = null
+    var messageId: String? = null
     var schemaFormat: String? = null
     var contentType: String? = null
     var name: String? = null
@@ -48,6 +49,9 @@ class MessageTrait {
 
     inline fun correlationIdRef(build: Reference.() -> Unit): Reference =
         Reference().apply(build).also { correlationId = it }
+
+    fun messageId(value: String): String =
+        value.also { messageId = it }
 
     fun schemaFormat(value: String): String =
         value.also { schemaFormat = it }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>kotlin-asyncapi-spring-web</module>
         <module>kotlin-asyncapi-script</module>
         <module>kotlin-asyncapi-maven-plugin</module>
+        <module>kotlin-asyncapi-annotation</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### What
As a first step to enable annotation based meta-documentation this PR adds the models for supporting the message component. 

### Why
- the annotation can be used to create the schema implementation from the annotated class

### How
- create model annotations for `Message` and its child components
