### PR TITLE
feat: Channel annotation processing

### DIFF
--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/CorrelationID.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/CorrelationID.kt
@@ -2,7 +2,6 @@ package org.openfolder.kotlinasyncapi.annotation
 
 annotation class CorrelationID(
     val default: Boolean = false,
-    val reference: String = "",
     val location: String,
     val description: String = ""
 )

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/Schema.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/Schema.kt
@@ -6,9 +6,8 @@ import kotlin.reflect.KClass
     AnnotationTarget.CLASS,
     AnnotationTarget.ANNOTATION_CLASS
 )
-@Repeatable
 @AsyncApiAnnotation
 annotation class Schema(
-    val default: Boolean = false,
-    val implementation: KClass<*> = Void::class
+    val value: KClass<*> = Void::class,
+    val default: Boolean = false
 )

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Channel.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Channel.kt
@@ -1,0 +1,19 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.AsyncApiAnnotation
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.ANNOTATION_CLASS
+)
+@AsyncApiAnnotation
+annotation class Channel(
+    val default: Boolean = false,
+    val reference: String = "",
+    val description: String = "",
+    val servers: Array<String> = [],
+    val subscribe: SubscribeOperation = SubscribeOperation(default = true),
+    val publish: PublishOperation = PublishOperation(default = true),
+    val parameters: Parameters = Parameters(default = true),
+    val bindings: ChannelBindings = ChannelBindings(default = true)
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Channel.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Channel.kt
@@ -9,11 +9,11 @@ import org.openfolder.kotlinasyncapi.annotation.AsyncApiAnnotation
 @AsyncApiAnnotation
 annotation class Channel(
     val default: Boolean = false,
-    val reference: String = "",
+    val key: String = "",
     val description: String = "",
     val servers: Array<String> = [],
-    val subscribe: SubscribeOperation = SubscribeOperation(default = true),
-    val publish: PublishOperation = PublishOperation(default = true),
-    val parameters: Parameters = Parameters(default = true),
+    val subscribe: Subscribe = Subscribe(default = true),
+    val publish: Publish = Publish(default = true),
+    val parameters: Array<Parameter> = [],
     val bindings: ChannelBindings = ChannelBindings(default = true)
 )

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Channel.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Channel.kt
@@ -8,8 +8,8 @@ import org.openfolder.kotlinasyncapi.annotation.AsyncApiAnnotation
 )
 @AsyncApiAnnotation
 annotation class Channel(
+    val value: String = "",
     val default: Boolean = false,
-    val key: String = "",
     val description: String = "",
     val servers: Array<String> = [],
     val subscribe: Subscribe = Subscribe(default = true),

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/ChannelBinding.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/ChannelBinding.kt
@@ -4,7 +4,6 @@ import org.openfolder.kotlinasyncapi.annotation.Schema
 
 annotation class ChannelBindings(
     val default: Boolean = false,
-    val reference: String = "",
     val http: ChannelBinding.HTTP = ChannelBinding.HTTP(default = true),
     val ws: ChannelBinding.WebSockets = ChannelBinding.WebSockets(default = true),
     val kafka: ChannelBinding.Kafka = ChannelBinding.Kafka(default = true),
@@ -28,6 +27,7 @@ sealed interface ChannelBinding {
 
     annotation class AnypointMQ(
         val default: Boolean = false,
+        val destination: String = "",
         val destinationType: String = "",
         val bindingVersion: String = ""
     )
@@ -85,6 +85,7 @@ sealed interface ChannelBinding {
 
     annotation class WebSockets(
         val default: Boolean = false,
+        val method: String = "",
         val bindingVersion: String = "",
         val query: Schema = Schema(default = true),
         val headers: Schema = Schema(default = true)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/ChannelBinding.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/ChannelBinding.kt
@@ -1,0 +1,118 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.Schema
+
+annotation class ChannelBindings(
+    val default: Boolean = false,
+    val reference: String = "",
+    val http: ChannelBinding.HTTP = ChannelBinding.HTTP(default = true),
+    val ws: ChannelBinding.WebSockets = ChannelBinding.WebSockets(default = true),
+    val kafka: ChannelBinding.Kafka = ChannelBinding.Kafka(default = true),
+    val anypointmq: ChannelBinding.AnypointMQ = ChannelBinding.AnypointMQ(default = true),
+    val amqp: ChannelBinding.AMQP = ChannelBinding.AMQP(default = true),
+    val amqp1: ChannelBinding.AMQP1 = ChannelBinding.AMQP1(default = true),
+    val mqtt: ChannelBinding.MQTT = ChannelBinding.MQTT(default = true),
+    val mqtt5: ChannelBinding.MQTT5 = ChannelBinding.MQTT5(default = true),
+    val nats: ChannelBinding.NATS = ChannelBinding.NATS(default = true),
+    val jms: ChannelBinding.JMS = ChannelBinding.JMS(default = true),
+    val sns: ChannelBinding.SNS = ChannelBinding.SNS(default = true),
+    val solace: ChannelBinding.Solace = ChannelBinding.Solace(default = true),
+    val sqs: ChannelBinding.SQS = ChannelBinding.SQS(default = true),
+    val stomp: ChannelBinding.STOMP = ChannelBinding.STOMP(default = true),
+    val redis: ChannelBinding.Redis = ChannelBinding.Redis(default = true),
+    val mercure: ChannelBinding.Mercure = ChannelBinding.Mercure(default = true),
+    val ibmmq: ChannelBinding.IBMMQ = ChannelBinding.IBMMQ(default = true)
+)
+
+sealed interface ChannelBinding {
+
+    annotation class AnypointMQ(
+        val default: Boolean = false,
+        val destinationType: String = "",
+        val bindingVersion: String = ""
+    )
+
+    annotation class AMQP(
+        val default: Boolean = false,
+        val `is`: String = "",
+        val bindingVersion: String = "",
+        val exchange: AMQPExchange = AMQPExchange(default = true),
+        val queue: AMQPQueue = AMQPQueue(default = true)
+    )
+
+    annotation class AMQPExchange(
+        val default: Boolean = false,
+        val name: String = "",
+        val type: String = "",
+        val durable: Boolean = false,
+        val autoDelete: Boolean = false,
+        val vhost: String = ""
+    )
+
+    annotation class AMQPQueue(
+        val default: Boolean = false,
+        val name: String = "",
+        val type: String = "",
+        val durable: Boolean = false,
+        val exclusive: Boolean = false,
+        val autoDelete: Boolean = false,
+        val vhost: String = ""
+    )
+
+    annotation class IBMMQ(
+        val default: Boolean = false,
+        val destinationType: String = "",
+        val bindingVersion: String = "",
+        val maxMsgLength: Int = 0,
+        val queue: IBMMQQueue = IBMMQQueue(default = true, objectName = ""),
+        val topic: IBMMQTopic = IBMMQTopic(default = true)
+    )
+
+    annotation class IBMMQQueue(
+        val default: Boolean = false,
+        val objectName: String,
+        val isPartitioned: Boolean = false,
+        val exclusive: Boolean = false
+    )
+
+    annotation class IBMMQTopic(
+        val default: Boolean = false,
+        val string: String = "",
+        val objectName: String = "",
+        val durablePermitted: Boolean = false,
+        val lastMsgRetained: Boolean = false
+    )
+
+    annotation class WebSockets(
+        val default: Boolean = false,
+        val bindingVersion: String = "",
+        val query: Schema = Schema(default = true),
+        val headers: Schema = Schema(default = true)
+    )
+
+    annotation class HTTP(val default: Boolean = false)
+
+    annotation class Kafka(val default: Boolean = false)
+
+    annotation class AMQP1(val default: Boolean = false)
+
+    annotation class MQTT(val default: Boolean = false)
+
+    annotation class MQTT5(val default: Boolean = false)
+
+    annotation class NATS(val default: Boolean = false)
+
+    annotation class JMS(val default: Boolean = false)
+
+    annotation class SNS(val default: Boolean = false)
+
+    annotation class Solace(val default: Boolean = false)
+
+    annotation class SQS(val default: Boolean = false)
+
+    annotation class STOMP(val default: Boolean = false)
+
+    annotation class Redis(val default: Boolean = false)
+
+    annotation class Mercure(val default: Boolean = false)
+}

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Message.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Message.kt
@@ -5,14 +5,15 @@ import org.openfolder.kotlinasyncapi.annotation.CorrelationID
 import org.openfolder.kotlinasyncapi.annotation.ExternalDocumentation
 import org.openfolder.kotlinasyncapi.annotation.Schema
 import org.openfolder.kotlinasyncapi.annotation.Tag
+import kotlin.reflect.KClass
 
 @Target(
     AnnotationTarget.CLASS,
     AnnotationTarget.ANNOTATION_CLASS
 )
-@Repeatable
 @AsyncApiAnnotation
 annotation class Message(
+    val value: KClass<*> = Void::class,
     val default: Boolean = false,
     val reference: String = "",
     val messageId: String = "",

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Message.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Message.kt
@@ -15,7 +15,6 @@ import kotlin.reflect.KClass
 annotation class Message(
     val value: KClass<*> = Void::class,
     val default: Boolean = false,
-    val reference: String = "",
     val messageId: String = "",
     val schemaFormat: String = "",
     val contentType: String = "",

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageBinding.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageBinding.kt
@@ -4,7 +4,6 @@ import org.openfolder.kotlinasyncapi.annotation.Schema
 
 annotation class MessageBindings(
     val default: Boolean = false,
-    val reference: String = "",
     val http: MessageBinding.HTTP = MessageBinding.HTTP(default = true),
     val ws: MessageBinding.WebSockets = MessageBinding.WebSockets(default = true),
     val kafka: MessageBinding.Kafka = MessageBinding.Kafka(default = true),

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageTrait.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/MessageTrait.kt
@@ -7,7 +7,6 @@ import org.openfolder.kotlinasyncapi.annotation.Tag
 
 annotation class MessageTrait(
     val default: Boolean = false,
-    val reference: String = "",
     val messageId: String = "",
     val schemaFormat: String = "",
     val contentType: String = "",

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Operation.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Operation.kt
@@ -9,12 +9,12 @@ import org.openfolder.kotlinasyncapi.annotation.Tag
     AnnotationTarget.ANNOTATION_CLASS
 )
 @AsyncApiAnnotation
-annotation class SubscribeOperation(
+annotation class Subscribe(
     val default: Boolean = false,
     val operationId: String = "",
     val summary: String = "",
     val description: String = "",
-    val security: Array<String> = [],
+    val security: Array<SecurityRequirement> = [],
     val tags: Array<Tag> = [],
     val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
     val bindings: OperationBindings = OperationBindings(default = true),
@@ -28,12 +28,12 @@ annotation class SubscribeOperation(
     AnnotationTarget.ANNOTATION_CLASS
 )
 @AsyncApiAnnotation
-annotation class PublishOperation(
+annotation class Publish(
     val default: Boolean = false,
     val operationId: String = "",
     val summary: String = "",
     val description: String = "",
-    val security: Array<String> = [],
+    val security: Array<SecurityRequirement> = [],
     val tags: Array<Tag> = [],
     val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
     val bindings: OperationBindings = OperationBindings(default = true),

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Operation.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Operation.kt
@@ -1,0 +1,43 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.AsyncApiAnnotation
+import org.openfolder.kotlinasyncapi.annotation.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.annotation.Tag
+
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.ANNOTATION_CLASS
+)
+@AsyncApiAnnotation
+annotation class SubscribeOperation(
+    val default: Boolean = false,
+    val operationId: String = "",
+    val summary: String = "",
+    val description: String = "",
+    val security: Array<String> = [],
+    val tags: Array<Tag> = [],
+    val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
+    val bindings: OperationBindings = OperationBindings(default = true),
+    val traits: Array<OperationTrait> = [],
+    val message: Message = Message(default = true),
+    val messages: Array<Message> = []
+)
+
+@Target(
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.ANNOTATION_CLASS
+)
+@AsyncApiAnnotation
+annotation class PublishOperation(
+    val default: Boolean = false,
+    val operationId: String = "",
+    val summary: String = "",
+    val description: String = "",
+    val security: Array<String> = [],
+    val tags: Array<Tag> = [],
+    val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
+    val bindings: OperationBindings = OperationBindings(default = true),
+    val traits: Array<OperationTrait> = [],
+    val message: Message = Message(default = true),
+    val messages: Array<Message> = []
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationBinding.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationBinding.kt
@@ -1,0 +1,117 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.Schema
+
+annotation class OperationBindings(
+    val default: Boolean = false,
+    val reference: String = "",
+    val http: OperationBinding.HTTP = OperationBinding.HTTP(default = true, type = ""),
+    val ws: OperationBinding.WebSockets = OperationBinding.WebSockets(default = true),
+    val kafka: OperationBinding.Kafka = OperationBinding.Kafka(default = true),
+    val anypointmq: OperationBinding.AnypointMQ = OperationBinding.AnypointMQ(default = true),
+    val amqp: OperationBinding.AMQP = OperationBinding.AMQP(default = true),
+    val amqp1: OperationBinding.AMQP1 = OperationBinding.AMQP1(default = true),
+    val mqtt: OperationBinding.MQTT = OperationBinding.MQTT(default = true),
+    val mqtt5: OperationBinding.MQTT5 = OperationBinding.MQTT5(default = true),
+    val nats: OperationBinding.NATS = OperationBinding.NATS(default = true),
+    val jms: OperationBinding.JMS = OperationBinding.JMS(default = true),
+    val sns: OperationBinding.SNS = OperationBinding.SNS(default = true),
+    val solace: OperationBinding.Solace = OperationBinding.Solace(default = true),
+    val sqs: OperationBinding.SQS = OperationBinding.SQS(default = true),
+    val stomp: OperationBinding.STOMP = OperationBinding.STOMP(default = true),
+    val redis: OperationBinding.Redis = OperationBinding.Redis(default = true),
+    val mercure: OperationBinding.Mercure = OperationBinding.Mercure(default = true),
+)
+
+sealed interface OperationBinding {
+
+    annotation class AMQP(
+        val default: Boolean = false,
+        val expiration: Int = 0,
+        val userId: String = "",
+        val cc: Array<String> = [],
+        val bcc: Array<String> = [],
+        val replyTo: String = "",
+        val timestamp: Boolean = false,
+        val ack: Boolean = false,
+        val priority: Int = 0,
+        val deliveryMode: Int = 0,
+        val mandatory: Boolean = false,
+        val bindingVersion: String = ""
+    )
+
+    annotation class HTTP(
+        val default: Boolean = false,
+        val type: String,
+        val method: String = "",
+        val query: Schema = Schema(default = true),
+        val bindingVersion: String = ""
+    )
+
+    annotation class Kafka(
+        val default: Boolean = false,
+        val bindingVersion: String = "",
+        val groupId: Schema = Schema(default = true),
+        val clientId: Schema = Schema(default = true)
+    )
+
+    annotation class MQTT(
+        val default: Boolean = false,
+        val qos: Int = 0,
+        val retain: Boolean = false,
+        val bindingVersion: String = ""
+    )
+
+    annotation class NATS(
+        val default: Boolean = false,
+        val queue: String = "",
+        val bindingVersion: String = ""
+    )
+
+
+    annotation class Solace(
+        val default: Boolean = false,
+        val bindingVersion: String = "",
+        val destinations: Array<SolaceDestination> = []
+    )
+
+    annotation class SolaceDestination(
+        val default: Boolean = false,
+        val destinationType: String = "",
+        val deliveryMode: String = "",
+        val queue: SolaceDestinationQueue = SolaceDestinationQueue(default = true),
+        val topic: SolaceDestinationTopic = SolaceDestinationTopic(default = true)
+    )
+
+    annotation class SolaceDestinationQueue(
+        val default: Boolean = false,
+        val name: String = "",
+        val accessType: String = "",
+        val topicSubscriptions: Array<String> = []
+    )
+
+    annotation class SolaceDestinationTopic(
+        val default: Boolean = false,
+        val topicSubscriptions: Array<String> = []
+    )
+
+    annotation class WebSockets(val default: Boolean = false)
+
+    annotation class AnypointMQ(val default: Boolean = false)
+
+    annotation class AMQP1(val default: Boolean = false)
+
+    annotation class MQTT5(val default: Boolean = false)
+
+    annotation class JMS(val default: Boolean = false)
+
+    annotation class SNS(val default: Boolean = false)
+
+    annotation class SQS(val default: Boolean = false)
+
+    annotation class STOMP(val default: Boolean = false)
+
+    annotation class Redis(val default: Boolean = false)
+
+    annotation class Mercure(val default: Boolean = false)
+}

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationBinding.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationBinding.kt
@@ -4,7 +4,6 @@ import org.openfolder.kotlinasyncapi.annotation.Schema
 
 annotation class OperationBindings(
     val default: Boolean = false,
-    val reference: String = "",
     val http: OperationBinding.HTTP = OperationBinding.HTTP(default = true, type = ""),
     val ws: OperationBinding.WebSockets = OperationBinding.WebSockets(default = true),
     val kafka: OperationBinding.Kafka = OperationBinding.Kafka(default = true),
@@ -67,7 +66,6 @@ sealed interface OperationBinding {
         val queue: String = "",
         val bindingVersion: String = ""
     )
-
 
     annotation class Solace(
         val default: Boolean = false,

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationTrait.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationTrait.kt
@@ -1,0 +1,15 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.annotation.Tag
+
+annotation class OperationTrait(
+    val default: Boolean = false,
+    val reference: String = "",
+    val operationId: String = "",
+    val summary: String = "",
+    val description: String = "",
+    val tags: Array<Tag> = [],
+    val externalDocs: ExternalDocumentation = ExternalDocumentation(default = true, url = ""),
+    val bindings: OperationBindings = OperationBindings(default = true)
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationTrait.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/OperationTrait.kt
@@ -5,7 +5,6 @@ import org.openfolder.kotlinasyncapi.annotation.Tag
 
 annotation class OperationTrait(
     val default: Boolean = false,
-    val reference: String = "",
     val operationId: String = "",
     val summary: String = "",
     val description: String = "",

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Parameter.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Parameter.kt
@@ -3,8 +3,8 @@ package org.openfolder.kotlinasyncapi.annotation.channel
 import org.openfolder.kotlinasyncapi.annotation.Schema
 
 annotation class Parameter(
+    val value: String = "",
     val default: Boolean = false,
-    val key: String = "",
     val description: String = "",
     val location: String = "",
     val schema: Schema = Schema(default = true)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Parameter.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Parameter.kt
@@ -2,9 +2,9 @@ package org.openfolder.kotlinasyncapi.annotation.channel
 
 import org.openfolder.kotlinasyncapi.annotation.Schema
 
-annotation class Parameters(
+annotation class Parameter(
     val default: Boolean = false,
-    val reference: String = "",
+    val key: String = "",
     val description: String = "",
     val location: String = "",
     val schema: Schema = Schema(default = true)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Parameter.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/Parameter.kt
@@ -1,0 +1,11 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+import org.openfolder.kotlinasyncapi.annotation.Schema
+
+annotation class Parameters(
+    val default: Boolean = false,
+    val reference: String = "",
+    val description: String = "",
+    val location: String = "",
+    val schema: Schema = Schema(default = true)
+)

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/SecurityRequirement.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/SecurityRequirement.kt
@@ -1,7 +1,7 @@
 package org.openfolder.kotlinasyncapi.annotation.channel
 
 annotation class SecurityRequirement(
-    val default: Boolean = false,
     val key: String = "",
+    val default: Boolean = false,
     val values: Array<String> = []
 )

--- a/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/SecurityRequirement.kt
+++ b/kotlin-asyncapi-annotation/src/main/kotlin/org/openfolder/kotlinasyncapi/annotation/channel/SecurityRequirement.kt
@@ -1,0 +1,7 @@
+package org.openfolder.kotlinasyncapi.annotation.channel
+
+annotation class SecurityRequirement(
+    val default: Boolean = false,
+    val key: String = "",
+    val values: Array<String> = []
+)

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
@@ -1,6 +1,7 @@
 package org.openfolder.kotlinasyncapi.springweb
 
 import org.openfolder.kotlinasyncapi.annotation.Schema
+import org.openfolder.kotlinasyncapi.annotation.channel.Channel
 import org.openfolder.kotlinasyncapi.annotation.channel.Message
 import org.openfolder.kotlinasyncapi.model.AsyncApi
 import org.openfolder.kotlinasyncapi.springweb.context.DefaultAnnotationProvider
@@ -10,6 +11,7 @@ import org.openfolder.kotlinasyncapi.springweb.context.ResourceProvider
 import org.openfolder.kotlinasyncapi.springweb.context.annotation.AnnotationScanner
 import org.openfolder.kotlinasyncapi.springweb.context.annotation.DefaultAnnotationScanner
 import org.openfolder.kotlinasyncapi.springweb.context.annotation.processor.AnnotationProcessor
+import org.openfolder.kotlinasyncapi.springweb.context.annotation.processor.ChannelProcessor
 import org.openfolder.kotlinasyncapi.springweb.context.annotation.processor.MessageProcessor
 import org.openfolder.kotlinasyncapi.springweb.context.annotation.processor.SchemaProcessor
 import org.openfolder.kotlinasyncapi.springweb.controller.AsyncApiController
@@ -103,6 +105,10 @@ internal open class AsyncApiAnnotationAutoConfiguration {
         SchemaProcessor()
 
     @Bean
+    open fun channelProcessor() =
+        ChannelProcessor()
+
+    @Bean
     open fun annotationScanner(context: ApplicationContext) =
         DefaultAnnotationScanner(context)
 
@@ -111,8 +117,9 @@ internal open class AsyncApiAnnotationAutoConfiguration {
         context: ApplicationContext,
         scanner: AnnotationScanner,
         messageProcessor: AnnotationProcessor<Message, KClass<*>>,
-        schemaProcessor: AnnotationProcessor<Schema, KClass<*>>
-    ) = DefaultAnnotationProvider(context, scanner, messageProcessor, schemaProcessor)
+        schemaProcessor: AnnotationProcessor<Schema, KClass<*>>,
+        channelProcessor: AnnotationProcessor<Channel, KClass<*>>
+    ) = DefaultAnnotationProvider(context, scanner, messageProcessor, schemaProcessor, channelProcessor)
 }
 
 @Configuration

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/AnnotationProvider.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/AnnotationProvider.kt
@@ -2,6 +2,7 @@ package org.openfolder.kotlinasyncapi.springweb.context
 
 import org.openfolder.kotlinasyncapi.annotation.AsyncApiAnnotation
 import org.openfolder.kotlinasyncapi.annotation.Schema
+import org.openfolder.kotlinasyncapi.annotation.channel.Channel
 import org.openfolder.kotlinasyncapi.annotation.channel.Message
 import org.openfolder.kotlinasyncapi.model.ReferencableCorrelationIDsMap
 import org.openfolder.kotlinasyncapi.model.ReferencableSchemasMap
@@ -36,7 +37,8 @@ internal class DefaultAnnotationProvider(
     context: ApplicationContext,
     scanner: AnnotationScanner,
     messageProcessor: AnnotationProcessor<Message, KClass<*>>,
-    schemaProcessor: AnnotationProcessor<Schema, KClass<*>>
+    schemaProcessor: AnnotationProcessor<Schema, KClass<*>>,
+    channelProcessor: AnnotationProcessor<Channel, KClass<*>>
 ) : AnnotationProvider {
 
     override val components: Components? by lazy {
@@ -54,13 +56,15 @@ internal class DefaultAnnotationProvider(
                 .flatMap { clazz ->
                     listOfNotNull(
                         clazz.findAnnotation<Message>()?.let { clazz to it },
-                        clazz.findAnnotation<Schema>()?.let { clazz to it }
+                        clazz.findAnnotation<Schema>()?.let { clazz to it },
+                        clazz.findAnnotation<Channel>()?.let { clazz to it }
                     )
                 }
                 .mapNotNull { (clazz, annotation) ->
                     when (annotation) {
                         is Message -> messageProcessor.process(annotation, clazz)
                         is Schema -> schemaProcessor.process(annotation, clazz)
+                        is Channel -> channelProcessor.process(annotation, clazz)
                         else -> null
                     }
                 }

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessor.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessor.kt
@@ -21,7 +21,7 @@ internal class ChannelProcessor : AnnotationProcessor<Channel, KClass<*>> {
                         publish = publish ?: context.findPublishOperation()?.toOperation()
                     }
                     .also { channel ->
-                        put(annotation.key.takeIf { it.isNotEmpty() } ?: context.java.simpleName, channel)
+                        put(annotation.value.takeIf { it.isNotEmpty() } ?: context.java.simpleName, channel)
                     }
             }
         }

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessor.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessor.kt
@@ -1,0 +1,35 @@
+package org.openfolder.kotlinasyncapi.springweb.context.annotation.processor
+
+import org.openfolder.kotlinasyncapi.annotation.channel.Channel
+import org.openfolder.kotlinasyncapi.annotation.channel.Publish
+import org.openfolder.kotlinasyncapi.annotation.channel.Subscribe
+import org.openfolder.kotlinasyncapi.model.component.Components
+import org.springframework.stereotype.Component
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.functions
+import kotlin.reflect.full.hasAnnotation
+
+@Component
+internal class ChannelProcessor : AnnotationProcessor<Channel, KClass<*>> {
+    override fun process(annotation: Channel, context: KClass<*>): Components {
+        return Components().apply {
+            channels {
+                annotation.toChannel()
+                    .apply {
+                        subscribe = subscribe ?: context.findSubscribeOperation()?.toOperation()
+                        publish = publish ?: context.findPublishOperation()?.toOperation()
+                    }
+                    .also { channel ->
+                        put(annotation.key.takeIf { it.isNotEmpty() } ?: context.java.simpleName, channel)
+                    }
+            }
+        }
+    }
+
+    private fun KClass<*>.findSubscribeOperation(): Subscribe? =
+        functions.firstOrNull { it.hasAnnotation<Subscribe>() }?.findAnnotation()
+
+    private fun KClass<*>.findPublishOperation(): Publish? =
+        functions.firstOrNull { it.hasAnnotation<Publish>() }?.findAnnotation()
+}

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MappingUtils.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MappingUtils.kt
@@ -329,7 +329,7 @@ internal fun Array<SecurityRequirement>.toSecurityRequirementsList(): SecurityRe
 
 internal fun Array<Parameter>.toReferencableParametersMap(): ReferencableParametersMap =
     ReferencableParametersMap().apply {
-        putAll(this@toReferencableParametersMap.map { it.key to it.toParameter() })
+        putAll(this@toReferencableParametersMap.map { it.value to it.toParameter() })
     }
 
 internal fun Parameter.toParameter(): org.openfolder.kotlinasyncapi.model.channel.Parameter =

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MappingUtils.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MappingUtils.kt
@@ -4,16 +4,34 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.openfolder.kotlinasyncapi.annotation.CorrelationID
 import org.openfolder.kotlinasyncapi.annotation.ExternalDocumentation
+import org.openfolder.kotlinasyncapi.annotation.Schema
 import org.openfolder.kotlinasyncapi.annotation.Tag
+import org.openfolder.kotlinasyncapi.annotation.channel.Channel
+import org.openfolder.kotlinasyncapi.annotation.channel.ChannelBinding
+import org.openfolder.kotlinasyncapi.annotation.channel.ChannelBindings
 import org.openfolder.kotlinasyncapi.annotation.channel.Message
 import org.openfolder.kotlinasyncapi.annotation.channel.MessageBinding
 import org.openfolder.kotlinasyncapi.annotation.channel.MessageBindings
 import org.openfolder.kotlinasyncapi.annotation.channel.MessageExample
 import org.openfolder.kotlinasyncapi.annotation.channel.MessageTrait
+import org.openfolder.kotlinasyncapi.annotation.channel.OperationBinding
+import org.openfolder.kotlinasyncapi.annotation.channel.OperationBindings
+import org.openfolder.kotlinasyncapi.annotation.channel.OperationTrait
+import org.openfolder.kotlinasyncapi.annotation.channel.Parameter
+import org.openfolder.kotlinasyncapi.annotation.channel.Publish
+import org.openfolder.kotlinasyncapi.annotation.channel.SecurityRequirement
+import org.openfolder.kotlinasyncapi.annotation.channel.Subscribe
 import org.openfolder.kotlinasyncapi.model.Reference
 import org.openfolder.kotlinasyncapi.model.TagsList
 import org.openfolder.kotlinasyncapi.model.channel.MessageExamplesList
 import org.openfolder.kotlinasyncapi.model.channel.MessageTraitsList
+import org.openfolder.kotlinasyncapi.model.channel.OneOfReferencableMessages
+import org.openfolder.kotlinasyncapi.model.channel.Operation
+import org.openfolder.kotlinasyncapi.model.channel.ReferencableMessagesList
+import org.openfolder.kotlinasyncapi.model.channel.ReferencableOperationTraitsList
+import org.openfolder.kotlinasyncapi.model.channel.ReferencableParametersMap
+import org.openfolder.kotlinasyncapi.model.server.SecurityRequirementsList
+import java.util.AbstractMap
 
 internal fun Message.toMessage(): org.openfolder.kotlinasyncapi.model.channel.Message =
     org.openfolder.kotlinasyncapi.model.channel.Message().apply {
@@ -30,12 +48,8 @@ internal fun Message.toMessage(): org.openfolder.kotlinasyncapi.model.channel.Me
         examples = this@toMessage.examples.takeUnless { it.isEmpty() }?.toMessageExamplesList()
         bindings = this@toMessage.bindings.takeUnless { it.default }?.toMessageBindings()
         traits = this@toMessage.traits.takeUnless { it.isEmpty() }?.toMessageTraitsList()
-        headers = this@toMessage.headers.takeUnless { it.default }?.value?.let {
-            Reference().apply { ref("#/components/schemas/${it.simpleName}") }
-        }
-        payload = this@toMessage.payload.takeUnless { it.default }?.value?.let {
-            Reference().apply { ref("#/components/schemas/${it.simpleName}") }
-        }
+        headers = this@toMessage.headers.takeUnless { it.default }?.toReference()
+        payload = this@toMessage.payload.takeUnless { it.default }?.toReference()
     }
 
 internal fun Array<Tag>.toTagsList(): TagsList =
@@ -110,33 +124,25 @@ internal fun MessageTrait.toMessageTrait(): org.openfolder.kotlinasyncapi.model.
         externalDocs = this@toMessageTrait.externalDocs.takeUnless { it.default }?.toExternalDocumentation()
         examples = this@toMessageTrait.examples.takeUnless { it.isEmpty() }?.toMessageExamplesList()
         bindings = this@toMessageTrait.bindings.takeUnless { it.default }?.toMessageBindings()
-        headers = this@toMessageTrait.headers.takeUnless { it.default }?.value?.let {
-            Reference().apply { ref("#/components/schemas/${it.simpleName}") }
-        }
+        headers = this@toMessageTrait.headers.takeUnless { it.default }?.toReference()
     }
 
 internal fun MessageBinding.HTTP.toHTTP(): org.openfolder.kotlinasyncapi.model.channel.MessageBinding.HTTP =
     org.openfolder.kotlinasyncapi.model.channel.MessageBinding.HTTP().apply {
         bindingVersion = this@toHTTP.bindingVersion.takeIf { it.isNotEmpty() }
-        headers = this@toHTTP.headers.takeUnless { it.default }?.value?.let {
-            Reference().apply { ref("#/components/schemas/${it.simpleName}") }
-        }
+        headers = this@toHTTP.headers.takeUnless { it.default }?.toReference()
     }
 
 internal fun MessageBinding.Kafka.toKafka(): org.openfolder.kotlinasyncapi.model.channel.MessageBinding.Kafka =
     org.openfolder.kotlinasyncapi.model.channel.MessageBinding.Kafka().apply {
         bindingVersion = this@toKafka.bindingVersion.takeIf { it.isNotEmpty() }
-        key = this@toKafka.key.takeUnless { it.default }?.value?.let {
-            Reference().apply { ref("#/components/schemas/${it.simpleName}") }
-        }
+        key = this@toKafka.key.takeUnless { it.default }?.toReference()
     }
 
 internal fun MessageBinding.AnypointMQ.toAnypointMQ(): org.openfolder.kotlinasyncapi.model.channel.MessageBinding.AnypointMQ =
     org.openfolder.kotlinasyncapi.model.channel.MessageBinding.AnypointMQ().apply {
         bindingVersion = this@toAnypointMQ.bindingVersion.takeIf { it.isNotEmpty() }
-        headers = this@toAnypointMQ.headers.takeUnless { it.default }?.value?.let {
-            Reference().apply { ref("#/components/schemas/${it.simpleName}") }
-        }
+        headers = this@toAnypointMQ.headers.takeUnless { it.default }?.toReference()
     }
 
 internal fun MessageBinding.AMQP.toAMQP(): org.openfolder.kotlinasyncapi.model.channel.MessageBinding.AMQP =
@@ -158,4 +164,251 @@ internal fun MessageBinding.IBMMQ.toIBMMQ(): org.openfolder.kotlinasyncapi.model
         description = this@toIBMMQ.description.takeIf { it.isNotEmpty() }
         expiry = this@toIBMMQ.expiry
         headers = this@toIBMMQ.headers.takeIf { it.isNotEmpty() }
+    }
+
+internal fun Channel.toChannel(): org.openfolder.kotlinasyncapi.model.channel.Channel =
+    org.openfolder.kotlinasyncapi.model.channel.Channel().apply {
+        description = this@toChannel.description.takeIf { it.isNotEmpty() }
+        servers = this@toChannel.servers.takeIf { it.isNotEmpty() }?.toList()
+        subscribe = this@toChannel.subscribe.takeUnless { it.default }?.toOperation()
+        publish = this@toChannel.publish.takeUnless { it.default }?.toOperation()
+        parameters = this@toChannel.parameters.takeIf { it.isNotEmpty() }?.toReferencableParametersMap()
+        bindings = this@toChannel.bindings.takeUnless { it.default }?.toChannelBindings()
+    }
+
+internal fun Subscribe.toOperation(): Operation =
+    Operation().apply {
+        operationId = this@toOperation.operationId.takeIf { it.isNotEmpty() }
+        summary = this@toOperation.summary.takeIf { it.isNotEmpty() }
+        description = this@toOperation.description.takeIf { it.isNotEmpty() }
+        security = this@toOperation.security.takeIf { it.isNotEmpty() }?.toSecurityRequirementsList()
+        tags = this@toOperation.tags.takeIf { it.isNotEmpty() }?.toTagsList()
+        externalDocs = this@toOperation.externalDocs.takeUnless { it.default }?.toExternalDocumentation()
+        bindings = this@toOperation.bindings.takeUnless { it.default }?.toOperationBindings()
+        traits = this@toOperation.traits.takeIf { it.isNotEmpty() }?.toReferencableOperationTraitsList()
+        message = this@toOperation.message.takeUnless { it.default }?.toReference()
+            ?: this@toOperation.messages.takeIf { it.isNotEmpty() }?.toOneOfReferencableMessages()
+    }
+
+internal fun Publish.toOperation(): Operation =
+    Operation().apply {
+        operationId = this@toOperation.operationId.takeIf { it.isNotEmpty() }
+        summary = this@toOperation.summary.takeIf { it.isNotEmpty() }
+        description = this@toOperation.description.takeIf { it.isNotEmpty() }
+        security = this@toOperation.security.takeIf { it.isNotEmpty() }?.toSecurityRequirementsList()
+        tags = this@toOperation.tags.takeIf { it.isNotEmpty() }?.toTagsList()
+        externalDocs = this@toOperation.externalDocs.takeUnless { it.default }?.toExternalDocumentation()
+        bindings = this@toOperation.bindings.takeUnless { it.default }?.toOperationBindings()
+        traits = this@toOperation.traits.takeIf { it.isNotEmpty() }?.toReferencableOperationTraitsList()
+        message = this@toOperation.message.takeUnless { it.default }?.toReference()
+            ?: this@toOperation.messages.takeIf { it.isNotEmpty() }?.toOneOfReferencableMessages()
+    }
+
+internal fun Message.toReference(): Reference =
+    Reference().apply {
+        ref("#/components/messages/${value.simpleName}")
+    }
+
+internal fun Schema.toReference(): Reference =
+    Reference().apply {
+        ref("#/components/schemas/${value.simpleName}")
+    }
+
+internal fun Array<Message>.toOneOfReferencableMessages(): OneOfReferencableMessages =
+    OneOfReferencableMessages().apply {
+        oneOf = toReferencableMessagesList()
+    }
+
+internal fun Array<Message>.toReferencableMessagesList(): ReferencableMessagesList =
+    ReferencableMessagesList().apply {
+        addAll(this@toReferencableMessagesList.map { it.toReference() })
+    }
+
+internal fun Array<OperationTrait>.toReferencableOperationTraitsList(): ReferencableOperationTraitsList =
+    ReferencableOperationTraitsList().apply {
+        addAll(this@toReferencableOperationTraitsList.map { it.toOperationTrait() })
+    }
+
+internal fun OperationTrait.toOperationTrait(): org.openfolder.kotlinasyncapi.model.channel.OperationTrait =
+    org.openfolder.kotlinasyncapi.model.channel.OperationTrait().apply {
+        operationId = this@toOperationTrait.operationId.takeIf { it.isNotEmpty() }
+        summary = this@toOperationTrait.summary.takeIf { it.isNotEmpty() }
+        description = this@toOperationTrait.description.takeIf { it.isNotEmpty() }
+        tags = this@toOperationTrait.tags.takeIf { it.isNotEmpty() }?.toTagsList()
+        externalDocs = this@toOperationTrait.externalDocs.takeUnless { it.default }?.toExternalDocumentation()
+        bindings = this@toOperationTrait.bindings.takeUnless { it.default }?.toOperationBindings()
+    }
+
+internal fun OperationBindings.toOperationBindings(): org.openfolder.kotlinasyncapi.model.channel.OperationBindings =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBindings().apply {
+        http = this@toOperationBindings.http.takeUnless { it.default }?.toHTTP()
+        kafka = this@toOperationBindings.kafka.takeUnless { it.default }?.toKafka()
+        amqp = this@toOperationBindings.amqp.takeUnless { it.default }?.toAMQP()
+        mqtt = this@toOperationBindings.mqtt.takeUnless { it.default }?.toMQTT()
+        nats = this@toOperationBindings.nats.takeUnless { it.default }?.toNATS()
+        solace = this@toOperationBindings.solace.takeUnless { it.default }?.toSolace()
+    }
+
+internal fun OperationBinding.HTTP.toHTTP(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.HTTP =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.HTTP().apply {
+        method = this@toHTTP.method.takeIf { it.isNotEmpty() }
+        query = this@toHTTP.query.takeUnless { it.default }?.toReference()
+        bindingVersion = this@toHTTP.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun OperationBinding.Kafka.toKafka(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Kafka =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Kafka().apply {
+        groupId = this@toKafka.groupId.takeUnless { it.default }?.toReference()
+        clientId = this@toKafka.clientId.takeUnless { it.default }?.toReference()
+        bindingVersion = this@toKafka.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun OperationBinding.AMQP.toAMQP(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.AMQP =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.AMQP().apply {
+        expiration = this@toAMQP.expiration
+        userId = this@toAMQP.userId.takeIf { it.isNotEmpty() }
+        cc = this@toAMQP.cc.takeIf { it.isNotEmpty() }?.toList()
+        priority = this@toAMQP.priority
+        deliveryMode = this@toAMQP.deliveryMode
+        mandatory = this@toAMQP.mandatory
+        bcc = this@toAMQP.bcc.takeIf { it.isNotEmpty() }?.toList()
+        replyTo = this@toAMQP.replyTo.takeIf { it.isNotEmpty() }
+        timestamp = this@toAMQP.timestamp
+        ack = this@toAMQP.ack
+        bindingVersion = this@toAMQP.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun OperationBinding.MQTT.toMQTT(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.MQTT =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.MQTT().apply {
+        qos = this@toMQTT.qos
+        retain = this@toMQTT.retain
+        bindingVersion = this@toMQTT.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun OperationBinding.NATS.toNATS(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.NATS =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.NATS().apply {
+        queue = this@toNATS.queue.takeIf { it.isNotEmpty() }
+        bindingVersion = this@toNATS.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun OperationBinding.Solace.toSolace(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace().apply {
+        bindingVersion = this@toSolace.bindingVersion.takeIf { it.isNotEmpty() }
+        destinations = this@toSolace.destinations.takeIf { it.isNotEmpty() }?.toSolaceDestinationsList()
+    }
+
+internal fun Array<OperationBinding.SolaceDestination>.toSolaceDestinationsList(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.DestinationsList =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.DestinationsList().apply {
+        addAll(this@toSolaceDestinationsList.map { it.toSolaceDestination() })
+    }
+
+internal fun OperationBinding.SolaceDestination.toSolaceDestination(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.Destination =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.Destination().apply {
+        destinationType = this@toSolaceDestination.destinationType.takeIf { it.isNotEmpty() }
+        deliveryMode = this@toSolaceDestination.deliveryMode.takeIf { it.isNotEmpty() }
+        queue = this@toSolaceDestination.queue.takeUnless { it.default }?.toSolaceDestinationQueue()
+        topic = this@toSolaceDestination.topic.takeUnless { it.default }?.toSolaceDestinationTopic()
+    }
+
+internal fun OperationBinding.SolaceDestinationQueue.toSolaceDestinationQueue(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.Queue =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.Queue().apply {
+        name = this@toSolaceDestinationQueue.name.takeIf { it.isNotEmpty() }
+        topicSubscriptions = this@toSolaceDestinationQueue.topicSubscriptions.takeIf { it.isNotEmpty() }?.toList()
+        accessType = this@toSolaceDestinationQueue.accessType.takeIf { it.isNotEmpty() }
+    }
+
+internal fun OperationBinding.SolaceDestinationTopic.toSolaceDestinationTopic(): org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.Topic =
+    org.openfolder.kotlinasyncapi.model.channel.OperationBinding.Solace.Topic().apply {
+        topicSubscriptions = this@toSolaceDestinationTopic.topicSubscriptions.takeIf { it.isNotEmpty() }?.toList()
+    }
+
+internal fun Array<SecurityRequirement>.toSecurityRequirementsList(): SecurityRequirementsList =
+    SecurityRequirementsList().apply {
+        addAll(this@toSecurityRequirementsList.map { AbstractMap.SimpleEntry(it.key, it.values.toList()) })
+    }
+
+internal fun Array<Parameter>.toReferencableParametersMap(): ReferencableParametersMap =
+    ReferencableParametersMap().apply {
+        putAll(this@toReferencableParametersMap.map { it.key to it.toParameter() })
+    }
+
+internal fun Parameter.toParameter(): org.openfolder.kotlinasyncapi.model.channel.Parameter =
+    org.openfolder.kotlinasyncapi.model.channel.Parameter().apply {
+        description = this@toParameter.description.takeIf { it.isNotEmpty() }
+        location = this@toParameter.location.takeIf { it.isNotEmpty() }
+        schema = this@toParameter.schema.takeUnless { it.default }?.toReference()
+    }
+
+internal fun ChannelBindings.toChannelBindings(): org.openfolder.kotlinasyncapi.model.channel.ChannelBindings =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBindings().apply {
+        ws = this@toChannelBindings.ws.takeUnless { it.default }?.toWebSockets()
+        anypointmq = this@toChannelBindings.anypointmq.takeUnless { it.default }?.toAnypointMQ()
+        amqp = this@toChannelBindings.amqp.takeUnless { it.default }?.toAMQP()
+        ibmmq = this@toChannelBindings.ibmmq.takeUnless { it.default }?.toIBMMQ()
+    }
+
+internal fun ChannelBinding.WebSockets.toWebSockets(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.WebSockets =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.WebSockets().apply {
+        method = this@toWebSockets.method.takeIf { it.isNotEmpty() }
+        query = this@toWebSockets.query.takeUnless { it.default }?.toReference()
+        headers = this@toWebSockets.headers.takeUnless { it.default }?.toReference()
+        bindingVersion = this@toWebSockets.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun ChannelBinding.AnypointMQ.toAnypointMQ(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AnypointMQ =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AnypointMQ().apply {
+        destination = this@toAnypointMQ.destination.takeIf { it.isNotEmpty() }
+        destinationType = this@toAnypointMQ.destinationType.takeIf { it.isNotEmpty() }
+        bindingVersion = this@toAnypointMQ.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun ChannelBinding.AMQP.toAMQP(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AMQP =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AMQP().apply {
+        `is` = this@toAMQP.`is`.takeIf { it.isNotEmpty() }
+        exchange = this@toAMQP.exchange.takeUnless { it.default }?.toAMQPExchange()
+        queue = this@toAMQP.queue.takeUnless { it.default }?.toAMQPQueue()
+        bindingVersion = this@toAMQP.bindingVersion.takeIf { it.isNotEmpty() }
+    }
+
+internal fun ChannelBinding.AMQPExchange.toAMQPExchange(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AMQP.Exchange =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AMQP.Exchange().apply {
+        name = this@toAMQPExchange.name.takeIf { it.isNotEmpty() }
+        type = this@toAMQPExchange.type.takeIf { it.isNotEmpty() }
+        vhost = this@toAMQPExchange.vhost.takeIf { it.isNotEmpty() }
+        durable = this@toAMQPExchange.durable
+        autoDelete = this@toAMQPExchange.autoDelete
+    }
+
+internal fun ChannelBinding.AMQPQueue.toAMQPQueue(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AMQP.Queue =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.AMQP.Queue().apply {
+        name = this@toAMQPQueue.name.takeIf { it.isNotEmpty() }
+        type = this@toAMQPQueue.type.takeIf { it.isNotEmpty() }
+        vhost = this@toAMQPQueue.vhost.takeIf { it.isNotEmpty() }
+        durable = this@toAMQPQueue.durable
+        exclusive = this@toAMQPQueue.exclusive
+        autoDelete = this@toAMQPQueue.autoDelete
+    }
+
+internal fun ChannelBinding.IBMMQ.toIBMMQ(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.IBMMQ =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.IBMMQ().apply {
+        destinationType = this@toIBMMQ.destinationType.takeIf { it.isNotEmpty() }
+        bindingVersion = this@toIBMMQ.bindingVersion.takeIf { it.isNotEmpty() }
+        maxMsgLength = this@toIBMMQ.maxMsgLength
+        queue = this@toIBMMQ.queue.takeUnless { it.default }?.toIBMMQQueue()
+        topic = this@toIBMMQ.topic.takeUnless { it.default }?.toIBMMQTopic()
+    }
+
+internal fun ChannelBinding.IBMMQQueue.toIBMMQQueue(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.IBMMQ.Queue =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.IBMMQ.Queue().apply {
+        objectName = this@toIBMMQQueue.objectName
+        isPartitioned = this@toIBMMQQueue.isPartitioned
+        exclusive = this@toIBMMQQueue.exclusive
+    }
+
+internal fun ChannelBinding.IBMMQTopic.toIBMMQTopic(): org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.IBMMQ.Topic =
+    org.openfolder.kotlinasyncapi.model.channel.ChannelBinding.IBMMQ.Topic().apply {
+        string = this@toIBMMQTopic.string.takeIf { it.isNotEmpty() }
+        objectName = this@toIBMMQTopic.objectName.takeIf { it.isNotEmpty() }
+        durablePermitted = this@toIBMMQTopic.durablePermitted
+        lastMsgRetained = this@toIBMMQTopic.lastMsgRetained
     }

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MappingUtils.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MappingUtils.kt
@@ -30,10 +30,10 @@ internal fun Message.toMessage(): org.openfolder.kotlinasyncapi.model.channel.Me
         examples = this@toMessage.examples.takeUnless { it.isEmpty() }?.toMessageExamplesList()
         bindings = this@toMessage.bindings.takeUnless { it.default }?.toMessageBindings()
         traits = this@toMessage.traits.takeUnless { it.isEmpty() }?.toMessageTraitsList()
-        headers = this@toMessage.headers.takeUnless { it.default }?.implementation?.let {
+        headers = this@toMessage.headers.takeUnless { it.default }?.value?.let {
             Reference().apply { ref("#/components/schemas/${it.simpleName}") }
         }
-        payload = this@toMessage.payload.takeUnless { it.default }?.implementation?.let {
+        payload = this@toMessage.payload.takeUnless { it.default }?.value?.let {
             Reference().apply { ref("#/components/schemas/${it.simpleName}") }
         }
     }
@@ -110,7 +110,7 @@ internal fun MessageTrait.toMessageTrait(): org.openfolder.kotlinasyncapi.model.
         externalDocs = this@toMessageTrait.externalDocs.takeUnless { it.default }?.toExternalDocumentation()
         examples = this@toMessageTrait.examples.takeUnless { it.isEmpty() }?.toMessageExamplesList()
         bindings = this@toMessageTrait.bindings.takeUnless { it.default }?.toMessageBindings()
-        headers = this@toMessageTrait.headers.takeUnless { it.default }?.implementation?.let {
+        headers = this@toMessageTrait.headers.takeUnless { it.default }?.value?.let {
             Reference().apply { ref("#/components/schemas/${it.simpleName}") }
         }
     }
@@ -118,7 +118,7 @@ internal fun MessageTrait.toMessageTrait(): org.openfolder.kotlinasyncapi.model.
 internal fun MessageBinding.HTTP.toHTTP(): org.openfolder.kotlinasyncapi.model.channel.MessageBinding.HTTP =
     org.openfolder.kotlinasyncapi.model.channel.MessageBinding.HTTP().apply {
         bindingVersion = this@toHTTP.bindingVersion.takeIf { it.isNotEmpty() }
-        headers = this@toHTTP.headers.takeUnless { it.default }?.implementation?.let {
+        headers = this@toHTTP.headers.takeUnless { it.default }?.value?.let {
             Reference().apply { ref("#/components/schemas/${it.simpleName}") }
         }
     }
@@ -126,7 +126,7 @@ internal fun MessageBinding.HTTP.toHTTP(): org.openfolder.kotlinasyncapi.model.c
 internal fun MessageBinding.Kafka.toKafka(): org.openfolder.kotlinasyncapi.model.channel.MessageBinding.Kafka =
     org.openfolder.kotlinasyncapi.model.channel.MessageBinding.Kafka().apply {
         bindingVersion = this@toKafka.bindingVersion.takeIf { it.isNotEmpty() }
-        key = this@toKafka.key.takeUnless { it.default }?.implementation?.let {
+        key = this@toKafka.key.takeUnless { it.default }?.value?.let {
             Reference().apply { ref("#/components/schemas/${it.simpleName}") }
         }
     }
@@ -134,7 +134,7 @@ internal fun MessageBinding.Kafka.toKafka(): org.openfolder.kotlinasyncapi.model
 internal fun MessageBinding.AnypointMQ.toAnypointMQ(): org.openfolder.kotlinasyncapi.model.channel.MessageBinding.AnypointMQ =
     org.openfolder.kotlinasyncapi.model.channel.MessageBinding.AnypointMQ().apply {
         bindingVersion = this@toAnypointMQ.bindingVersion.takeIf { it.isNotEmpty() }
-        headers = this@toAnypointMQ.headers.takeUnless { it.default }?.implementation?.let {
+        headers = this@toAnypointMQ.headers.takeUnless { it.default }?.value?.let {
             Reference().apply { ref("#/components/schemas/${it.simpleName}") }
         }
     }

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessorTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessorTest.kt
@@ -1,0 +1,87 @@
+package org.openfolder.kotlinasyncapi.springweb.context.annotation.processor
+
+import org.junit.jupiter.api.Test
+import org.openfolder.kotlinasyncapi.annotation.Tag
+import org.openfolder.kotlinasyncapi.annotation.channel.Channel
+import org.openfolder.kotlinasyncapi.annotation.channel.Message
+import org.openfolder.kotlinasyncapi.annotation.channel.Parameter
+import org.openfolder.kotlinasyncapi.annotation.channel.Publish
+import org.openfolder.kotlinasyncapi.annotation.channel.SecurityRequirement
+import org.openfolder.kotlinasyncapi.annotation.channel.Subscribe
+import org.openfolder.kotlinasyncapi.springweb.TestUtils
+import kotlin.reflect.full.findAnnotation
+
+internal class ChannelProcessorTest {
+
+    private val processor = ChannelProcessor()
+
+    @Test
+    fun `should process channel annotation`() {
+        val payload = TestChannel::class
+        val annotation = payload.findAnnotation<Channel>()!!
+
+        val expected = TestUtils.json("annotation/channel_component.json")
+        val actual = TestUtils.json(processor.process(annotation, payload))
+
+        TestUtils.assertJsonEquals(expected, actual)
+    }
+
+    @Channel(
+        key = "some/{parameter}/sqs",
+        description = "testDescription",
+        servers = ["sqs"],
+        parameters = [
+            Parameter(
+                key = "parameter",
+                description = "testDescription"
+            )
+        ]
+    )
+    class TestChannel {
+
+        @Subscribe(
+            operationId = "testOperationId",
+            security = [
+                SecurityRequirement(
+                    key = "petstore_auth",
+                    values = ["write:pets", "read:pets"]
+                )
+            ],
+            message = Message(TestSubscribeMessage::class)
+        )
+        fun testSubscribe() {}
+
+        @Publish(
+            description = "testDescription",
+            tags = [
+                Tag(name = "testTag")
+            ],
+            messages = [
+                Message(TestPublishMessage::class),
+                Message(TestPublishMessage2::class)
+            ]
+        )
+        fun testPublish() {}
+    }
+
+    @Message
+    data class TestSubscribeMessage(
+        val id: Int = 0,
+        val name: String,
+        val isTest: Boolean
+    )
+
+    @Message
+    data class TestPublishMessage(
+        val id: Int = 0,
+        val name: String,
+        val isTest: Boolean
+    )
+
+    @Message
+    data class TestPublishMessage2(
+        val id: Int = 0,
+        val name: String,
+        val isTest: Boolean
+    )
+}

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessorTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessorTest.kt
@@ -27,12 +27,12 @@ internal class ChannelProcessorTest {
     }
 
     @Channel(
-        key = "some/{parameter}/sqs",
+        value = "some/{parameter}/sqs",
         description = "testDescription",
         servers = ["sqs"],
         parameters = [
             Parameter(
-                key = "parameter",
+                value = "parameter",
                 description = "testDescription"
             )
         ]

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessorTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ChannelProcessorTest.kt
@@ -27,9 +27,9 @@ internal class ChannelProcessorTest {
     }
 
     @Channel(
-        value = "some/{parameter}/sqs",
+        value = "some/{parameter}/channel",
         description = "testDescription",
-        servers = ["sqs"],
+        servers = ["dev"],
         parameters = [
             Parameter(
                 value = "parameter",

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MessageProcessorTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MessageProcessorTest.kt
@@ -27,7 +27,7 @@ internal class MessageProcessorTest {
         name = "testName",
         description = "testDescription",
         tags = [Tag(name = "testName")],
-        headers = Schema(implementation = TestHeaders::class)
+        headers = Schema(TestHeaders::class)
     )
     data class TestPayload(
         val id: Int = 0,

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
@@ -43,9 +43,9 @@ internal class DefaultAnnotationProviderTest {
     open class TestConfig
 
     @Channel(
-        key = "test/{parameter}/sqs",
+        value = "test/{parameter}/sqs",
         description = "testDescription",
-        parameters = [Parameter(key = "parameter")],
+        parameters = [Parameter("parameter")],
         bindings = ChannelBindings(amqp = ChannelBinding.AMQP(bindingVersion = "1.0"))
     )
     class TestChannel {

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
@@ -43,7 +43,7 @@ internal class DefaultAnnotationProviderTest {
     open class TestConfig
 
     @Channel(
-        value = "test/{parameter}/sqs",
+        value = "test/{parameter}/channel",
         description = "testDescription",
         parameters = [Parameter("parameter")],
         bindings = ChannelBindings(amqp = ChannelBinding.AMQP(bindingVersion = "1.0"))

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
@@ -4,10 +4,17 @@ import org.junit.jupiter.api.Test
 import org.openfolder.kotlinasyncapi.annotation.ExternalDocumentation
 import org.openfolder.kotlinasyncapi.annotation.Schema
 import org.openfolder.kotlinasyncapi.annotation.Tag
+import org.openfolder.kotlinasyncapi.annotation.channel.Channel
+import org.openfolder.kotlinasyncapi.annotation.channel.ChannelBinding
+import org.openfolder.kotlinasyncapi.annotation.channel.ChannelBindings
 import org.openfolder.kotlinasyncapi.annotation.channel.Message
 import org.openfolder.kotlinasyncapi.annotation.channel.MessageBinding
 import org.openfolder.kotlinasyncapi.annotation.channel.MessageBindings
 import org.openfolder.kotlinasyncapi.annotation.channel.MessageExample
+import org.openfolder.kotlinasyncapi.annotation.channel.OperationBinding
+import org.openfolder.kotlinasyncapi.annotation.channel.OperationBindings
+import org.openfolder.kotlinasyncapi.annotation.channel.Parameter
+import org.openfolder.kotlinasyncapi.annotation.channel.Subscribe
 import org.openfolder.kotlinasyncapi.springweb.EnableAsyncApi
 import org.openfolder.kotlinasyncapi.springweb.TestUtils
 import org.openfolder.kotlinasyncapi.springweb.context.DefaultAnnotationProvider
@@ -35,13 +42,29 @@ internal class DefaultAnnotationProviderTest {
     @EnableAsyncApi
     open class TestConfig
 
+    @Channel(
+        key = "test/{parameter}/sqs",
+        description = "testDescription",
+        parameters = [Parameter(key = "parameter")],
+        bindings = ChannelBindings(amqp = ChannelBinding.AMQP(bindingVersion = "1.0"))
+    )
+    class TestChannel {
+
+        @Subscribe(
+            description = "testDescription",
+            bindings = OperationBindings(amqp = OperationBinding.AMQP(bindingVersion = "1.0")),
+            message = Message(TestMessage::class)
+        )
+        fun testOperation() {}
+    }
+
     @Message(
         messageId = "testMessageId",
         name = "testName",
         description = "testDescription",
         headers = Schema(TestHeaders::class),
         externalDocs = ExternalDocumentation(url = "http://example.com"),
-        bindings = MessageBindings(http = MessageBinding.HTTP(bindingVersion = "1.0")),
+        bindings = MessageBindings(amqp = MessageBinding.AMQP(bindingVersion = "1.0")),
         examples = [MessageExample(headers = "{\"type\":\"TEST\"}", payload = "{\"body\":\"body test\"}")],
         tags = [Tag(name = "testName")]
     )

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/external/DefaultAnnotationProviderTest.kt
@@ -39,7 +39,7 @@ internal class DefaultAnnotationProviderTest {
         messageId = "testMessageId",
         name = "testName",
         description = "testDescription",
-        headers = Schema(implementation = TestHeaders::class),
+        headers = Schema(TestHeaders::class),
         externalDocs = ExternalDocumentation(url = "http://example.com"),
         bindings = MessageBindings(http = MessageBinding.HTTP(bindingVersion = "1.0")),
         examples = [MessageExample(headers = "{\"type\":\"TEST\"}", payload = "{\"body\":\"body test\"}")],

--- a/kotlin-asyncapi-spring-web/src/test/resources/annotation/annotation_integration.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/annotation/annotation_integration.json
@@ -1,6 +1,6 @@
 {
   "channels" : {
-    "test/{parameter}/sqs" : {
+    "test/{parameter}/channel" : {
       "description" : "testDescription",
       "subscribe" : {
         "description" : "testDescription",

--- a/kotlin-asyncapi-spring-web/src/test/resources/annotation/annotation_integration.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/annotation/annotation_integration.json
@@ -1,82 +1,100 @@
 {
-  "messages": {
-    "TestMessage": {
-      "messageId": "testMessageId",
-      "headers": {
-        "$ref": "#/components/schemas/TestHeaders"
-      },
-      "payload": {
-        "$ref": "#/components/schemas/TestMessage"
-      },
-      "schemaFormat": "application/schema+json;version=draft-07",
-      "name": "testName",
-      "description": "testDescription",
-      "tags": [
-        {
-          "name": "testName"
-        }
-      ],
-      "externalDocs": {
-        "url": "http://example.com"
-      },
-      "bindings": {
-        "http": {
-          "bindingVersion": "1.0"
-        }
-      },
-      "examples": [
-        {
-          "headers": {
-            "type": "TEST"
-          },
-          "payload": {
-            "body": "body test"
+  "channels" : {
+    "test/{parameter}/sqs" : {
+      "description" : "testDescription",
+      "subscribe" : {
+        "description" : "testDescription",
+        "bindings" : {
+          "amqp" : {
+            "expiration" : 0,
+            "priority" : 0,
+            "deliveryMode" : 0,
+            "mandatory" : false,
+            "timestamp" : false,
+            "ack" : false,
+            "bindingVersion" : "1.0"
           }
+        },
+        "message" : {
+          "$ref" : "#/components/messages/TestMessage"
         }
-      ]
+      },
+      "parameters" : {
+        "parameter" : { }
+      },
+      "bindings" : {
+        "amqp" : {
+          "bindingVersion" : "1.0"
+        }
+      }
     }
   },
-  "schemas": {
-    "TestHeaders": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "exampleSetFlag": false,
-          "types": [
-            "string"
-          ]
+  "messages" : {
+    "TestMessage" : {
+      "messageId" : "testMessageId",
+      "headers" : {
+        "$ref" : "#/components/schemas/TestHeaders"
+      },
+      "payload" : {
+        "$ref" : "#/components/schemas/TestMessage"
+      },
+      "schemaFormat" : "application/schema+json;version=draft-07",
+      "name" : "testName",
+      "description" : "testDescription",
+      "tags" : [ {
+        "name" : "testName"
+      } ],
+      "externalDocs" : {
+        "url" : "http://example.com"
+      },
+      "bindings" : {
+        "amqp" : {
+          "bindingVersion" : "1.0"
         }
       },
-      "exampleSetFlag": false
+      "examples" : [ {
+        "headers" : {
+          "type" : "TEST"
+        },
+        "payload" : {
+          "body" : "body test"
+        }
+      } ]
+    }
+  },
+  "schemas" : {
+    "TestHeaders" : {
+      "type" : "object",
+      "properties" : {
+        "type" : {
+          "type" : "string",
+          "exampleSetFlag" : false,
+          "types" : [ "string" ]
+        }
+      },
+      "exampleSetFlag" : false
     },
-    "TestMessage": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "integer",
-          "format": "int32",
-          "exampleSetFlag": false,
-          "types": [
-            "integer"
-          ]
+    "TestMessage" : {
+      "type" : "object",
+      "properties" : {
+        "id" : {
+          "type" : "integer",
+          "format" : "int32",
+          "exampleSetFlag" : false,
+          "types" : [ "integer" ]
         },
-        "name": {
-          "type": "string",
-          "exampleSetFlag": false,
-          "types": [
-            "string"
-          ]
+        "name" : {
+          "type" : "string",
+          "exampleSetFlag" : false,
+          "types" : [ "string" ]
         },
-        "test": {
-          "type": "boolean",
-          "exampleSetFlag": false,
-          "types": [
-            "boolean"
-          ]
+        "test" : {
+          "type" : "boolean",
+          "exampleSetFlag" : false,
+          "types" : [ "boolean" ]
         }
       },
-      "exampleSetFlag": false
+      "exampleSetFlag" : false
     }
   }
 }

--- a/kotlin-asyncapi-spring-web/src/test/resources/annotation/channel_component.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/annotation/channel_component.json
@@ -1,0 +1,35 @@
+{
+  "channels" : {
+    "some/{parameter}/sqs" : {
+      "description" : "testDescription",
+      "servers" : [ "sqs" ],
+      "subscribe" : {
+        "operationId" : "testOperationId",
+        "security" : [ {
+          "petstore_auth" : [ "write:pets", "read:pets" ]
+        } ],
+        "message" : {
+          "$ref" : "#/components/messages/TestSubscribeMessage"
+        }
+      },
+      "publish" : {
+        "description" : "testDescription",
+        "tags" : [ {
+          "name" : "testTag"
+        } ],
+        "message" : {
+          "oneOf" : [ {
+            "$ref" : "#/components/messages/TestPublishMessage"
+          }, {
+            "$ref" : "#/components/messages/TestPublishMessage2"
+          } ]
+        }
+      },
+      "parameters" : {
+        "parameter" : {
+          "description" : "testDescription"
+        }
+      }
+    }
+  }
+}

--- a/kotlin-asyncapi-spring-web/src/test/resources/annotation/channel_component.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/annotation/channel_component.json
@@ -1,8 +1,8 @@
 {
   "channels" : {
-    "some/{parameter}/sqs" : {
+    "some/{parameter}/channel" : {
       "description" : "testDescription",
-      "servers" : [ "sqs" ],
+      "servers" : [ "dev" ],
       "subscribe" : {
         "operationId" : "testOperationId",
         "security" : [ {


### PR DESCRIPTION
### What
The PR adds the Channel and Operation annotations as well as their processing implementation.

### Why
- enables users to annotate classes as channels and member functions as subscribe/publish operations

### How
- add Channel and Operation annotations to annotation module
- add channel annotation processor 
