### PR TITLE
feat: Add Kotlin module to model resolver

### DIFF
--- a/kotlin-asyncapi-spring-web/pom.xml
+++ b/kotlin-asyncapi-spring-web/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-kotlin</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.swagger.core.v3</groupId>
             <artifactId>swagger-core</artifactId>
         </dependency>

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ConverterUtils.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/ConverterUtils.kt
@@ -1,0 +1,9 @@
+package org.openfolder.kotlinasyncapi.springweb.context.annotation.processor
+
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.swagger.v3.core.converter.ModelConverters
+import io.swagger.v3.core.jackson.ModelResolver
+
+internal val MODEL_RESOLVER = ModelConverters().also {
+    (it.converters.first() as ModelResolver).objectMapper().registerKotlinModule()
+}

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MessageProcessor.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/MessageProcessor.kt
@@ -1,6 +1,5 @@
 package org.openfolder.kotlinasyncapi.springweb.context.annotation.processor
 
-import io.swagger.v3.core.converter.ModelConverters
 import org.openfolder.kotlinasyncapi.annotation.channel.Message
 import org.openfolder.kotlinasyncapi.model.Reference
 import org.openfolder.kotlinasyncapi.model.component.Components
@@ -10,8 +9,7 @@ import kotlin.reflect.KClass
 @Component
 internal class MessageProcessor : AnnotationProcessor<Message, KClass<*>> {
     override fun process(annotation: Message, context: KClass<*>): Components {
-        val converters = ModelConverters()
-        val jsonSchema = converters.readAll(context.java)
+        val jsonSchema = MODEL_RESOLVER.readAll(context.java)
 
         return Components().apply {
             messages {

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/SchemaProcessor.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/SchemaProcessor.kt
@@ -1,6 +1,5 @@
 package org.openfolder.kotlinasyncapi.springweb.context.annotation.processor
 
-import io.swagger.v3.core.converter.ModelConverters
 import org.openfolder.kotlinasyncapi.annotation.Schema
 import org.openfolder.kotlinasyncapi.model.component.Components
 import org.springframework.stereotype.Component
@@ -9,8 +8,7 @@ import kotlin.reflect.KClass
 @Component
 internal class SchemaProcessor : AnnotationProcessor<Schema, KClass<*>> {
     override fun process(annotation: Schema, context: KClass<*>): Components {
-        val converters = ModelConverters()
-        val jsonSchema = converters.readAll(context.java)
+        val jsonSchema = MODEL_RESOLVER.readAll(context.java)
 
         return Components().apply {
             schemas {

--- a/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/SchemaProcessorTest.kt
+++ b/kotlin-asyncapi-spring-web/src/test/kotlin/org/openfolder/kotlinasyncapi/springweb/context/annotation/processor/SchemaProcessorTest.kt
@@ -25,7 +25,7 @@ internal class SchemaProcessorTest {
         val id: Int = 0,
         val name: String,
         val isTest: Boolean,
-        val sub: TestSubSchema
+        val sub: TestSubSchema?
     )
 
     data class TestSubSchema(

--- a/kotlin-asyncapi-spring-web/src/test/resources/annotation/annotation_integration.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/annotation/annotation_integration.json
@@ -58,6 +58,7 @@
   },
   "schemas" : {
     "TestHeaders" : {
+      "required" : [ "type" ],
       "type" : "object",
       "properties" : {
         "type" : {
@@ -69,6 +70,7 @@
       "exampleSetFlag" : false
     },
     "TestMessage" : {
+      "required" : [ "id", "isTest", "name" ],
       "type" : "object",
       "properties" : {
         "id" : {
@@ -82,7 +84,7 @@
           "exampleSetFlag" : false,
           "types" : [ "string" ]
         },
-        "test" : {
+        "isTest" : {
           "type" : "boolean",
           "exampleSetFlag" : false,
           "types" : [ "boolean" ]

--- a/kotlin-asyncapi-spring-web/src/test/resources/annotation/message_component.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/annotation/message_component.json
@@ -18,6 +18,7 @@
   },
   "schemas" : {
     "TestPayload" : {
+      "required" : [ "id", "isTest", "name" ],
       "type" : "object",
       "properties" : {
         "id" : {
@@ -31,7 +32,7 @@
           "exampleSetFlag" : false,
           "types" : [ "string" ]
         },
-        "test" : {
+        "isTest" : {
           "type" : "boolean",
           "exampleSetFlag" : false,
           "types" : [ "boolean" ]

--- a/kotlin-asyncapi-spring-web/src/test/resources/annotation/schema_component.json
+++ b/kotlin-asyncapi-spring-web/src/test/resources/annotation/schema_component.json
@@ -1,6 +1,7 @@
 {
   "schemas" : {
     "TestSchema" : {
+      "required" : [ "id", "isTest", "name" ],
       "type" : "object",
       "properties" : {
         "id" : {
@@ -14,19 +15,20 @@
           "exampleSetFlag" : false,
           "types" : [ "string" ]
         },
-        "sub" : {
-          "$ref" : "#/components/schemas/TestSubSchema",
-          "exampleSetFlag" : false
-        },
-        "test" : {
+        "isTest" : {
           "type" : "boolean",
           "exampleSetFlag" : false,
           "types" : [ "boolean" ]
+        },
+        "sub" : {
+          "$ref" : "#/components/schemas/TestSubSchema",
+          "exampleSetFlag" : false
         }
       },
       "exampleSetFlag" : false
     },
     "TestSubSchema" : {
+      "required" : [ "exists" ],
       "type" : "object",
       "properties" : {
         "exists" : {

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,11 @@
                 <version>2.14.2</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-kotlin</artifactId>
+                <version>2.14.2</version>
+            </dependency>
+            <dependency>
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-core</artifactId>
                 <version>2.2.8</version>


### PR DESCRIPTION
### What
Add the Colton module to the object mapper of the model revolver. 

### Why
- add Kotlin support for language features like Data Classes and Nullable properties.

### How
- register Kotlin module to the object mapper of the model resolver
