### PR TITLE
fix: Use correct extension order

### DIFF
--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
@@ -53,11 +53,11 @@ internal open class AsyncApiAutoConfiguration {
 
     @Bean
     open fun asyncApiPackageInfoExtension(packageInfoProvider: AsyncApiContextProvider) =
-        packageInfoProvider.asyncApi?.let { AsyncApiExtension.from(order = -1, it) }
+        packageInfoProvider.asyncApi?.let { AsyncApiExtension.from(order = -10, it) }
 
     @Bean
     open fun asyncApiDefaultChannelsExtension() =
-        AsyncApiExtension.builder(order = -1) {
+        AsyncApiExtension.builder(order = -10) {
             channels { }
         }
 
@@ -81,7 +81,7 @@ internal open class AsyncApiScriptAutoConfiguration {
 
     @Bean
     open fun asyncApiPackageResourceExtension(packageResourceProvider: AsyncApiContextProvider) =
-        packageResourceProvider.asyncApi?.let { AsyncApiExtension.from(order = -1, it) }
+        packageResourceProvider.asyncApi?.let { AsyncApiExtension.from(resource = it) }
 }
 
 @Configuration


### PR DESCRIPTION
### What
The registered extension beans must be in the correct order to avoid unexpected behaviour. 

### Why
- channels defined via annotations should not be overwritten by the default channel extension 

### How
- use correct extension order
