### PR TITLE
fix: Move property check to marker configuration

### DIFF
--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
@@ -132,6 +132,7 @@ internal open class AsyncApiEmbeddedScriptAutoConfiguration {
 }
 
 @Configuration
+@ConditionalOnProperty(name = ["asyncapi.enabled"], havingValue = "true", matchIfMissing = true)
 internal open class AsyncApiMarkerConfiguration {
 
     @Bean

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/EnableAsyncApi.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/EnableAsyncApi.kt
@@ -1,10 +1,8 @@
 package org.openfolder.kotlinasyncapi.springweb
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Import
 
 @Target(AnnotationTarget.CLASS)
 @MustBeDocumented
 @Import(AsyncApiMarkerConfiguration::class)
-@ConditionalOnProperty(name = ["asyncapi.enabled"], havingValue = "true", matchIfMissing = true)
 annotation class EnableAsyncApi


### PR DESCRIPTION
### What
The property check for the `asyncapi.enabled` configuration should not be applied to the annotation but the marker configuration bean.

### Why
- the `EnableAsyncApi` annotation could produce unintended behaviour (break application if applied to Spring Boot Application class)

### How
- move the property check to the configuration bean
