### PR TITLE
chore: Replace classpath scanner implementation

### DIFF
--- a/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Channel.kt
+++ b/kotlin-asyncapi-core/src/main/kotlin/org/openfolder/kotlinasyncapi/model/channel/Channel.kt
@@ -22,7 +22,10 @@ class Channel {
     var parameters: ReferencableParametersMap? = null
     var bindings: Any? = null
 
-    @Deprecated("Usage of the \$ref property has been deprecated")
+    @Deprecated(
+        message = "Usage of the \$ref property has been deprecated",
+        replaceWith = ReplaceWith("Reference().ref()")
+    )
     fun ref(value: String): String =
         value.also { `$ref` = it }
 

--- a/kotlin-asyncapi-spring-web/pom.xml
+++ b/kotlin-asyncapi-spring-web/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>swagger-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>[5.3.13,5.3.24]</version>

--- a/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
+++ b/kotlin-asyncapi-spring-web/src/main/kotlin/org/openfolder/kotlinasyncapi/springweb/AsyncApiAutoConfiguration.kt
@@ -101,8 +101,8 @@ internal open class AsyncApiAnnotationAutoConfiguration {
         ChannelProcessor()
 
     @Bean
-    open fun annotationScanner(context: ApplicationContext) =
-        DefaultAnnotationScanner(context)
+    open fun annotationScanner() =
+        DefaultAnnotationScanner()
 
     @Bean
     open fun annotationProvider(

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,11 @@
                 <version>2.2.8</version>
             </dependency>
             <dependency>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>4.8.157</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-scripting-jvm-host</artifactId>
                 <version>${kotlin.version}</version>


### PR DESCRIPTION
### What
Use ClassGraph instead of the Spring `ClassPathScanningCandidateComponentProvider`.

### Why
- `ClassPathScanningCandidateComponentProvider` does not include conditional Beans in the scanning result

### How
- use ClassGraph in the `DefaultAnnotationScanner` implementation
